### PR TITLE
Tweak CSS for xarray display

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -34,3 +34,24 @@ div.document a:visited {
 .wy-nav-content {
     background-color: white;
 }
+
+/*Fixes for xarray display issues*/
+.rst-content dl.xr-attrs dt, .rst-content dl.xr-attrs dd {
+     margin: 0px 0 !important;
+     font-size: inherit !important;
+     background: inherit !important;
+     color: inherit !important;
+     border-top: none !important;
+     padding: 0px 10px 0px 0px !important;
+     float: left !important;
+     white-space: nowrap !important;
+     overflow: hidden !important;
+     text-overflow: ellipsis !important;
+}
+ .rst-content dl.xr-attrs dt {
+     font-weight: normal !important;
+     grid-column: 1 !important;
+}
+ .rst-content dl.xr-attrs dd {
+     grid-column: 2 !important;
+}


### PR DESCRIPTION
Some of the theme defaults override styling included by xarray display, see issue here:

![xr-css-issue-before](https://user-images.githubusercontent.com/1428024/141030543-828c353c-e73b-4acc-8739-28fcb04aa9ed.png)

With these overrides it should like this afterwardss:

![xr-css-issue-after](https://user-images.githubusercontent.com/1428024/141030555-c1b3960c-0357-4d2b-9252-b3ffbb8e7b8b.png)

