### PR TITLE
Add "Downloading DEA data" section to FAQ

### DIFF
--- a/about/faq.rst
+++ b/about/faq.rst
@@ -10,7 +10,7 @@ There are several options for downloading data from DEA depending on your use ca
 
 **1) You want to download a small area of data from a specific satellite image**
 
-Use `DEA Maps`_ to directly export a small amount of data from the map using the :ref:`Export functionality <dea_maps_exporting>`. This is the easiest method, but it is not suitable for downloading large areas of data or multiple steps (see below).
+Use :ref:`DEA Maps <dea_maps>` to directly export a small amount of data from the map using the :ref:`Export functionality <dea_maps_exporting>`. This is the easiest method, but it is not suitable for downloading large areas of data or multiple steps (see below).
 
 **2) You want to download all available data for a bounding box and/or time range**
 

--- a/about/faq.rst
+++ b/about/faq.rst
@@ -26,9 +26,10 @@ Download data directly from our `Amazon S3 buckets`_ using the AWS Command Line 
 
 .. _Amazon S3 buckets:  ../setup/AWS/data_and_metadata.rst
 
-To download multiple files::
+To download multiple files, for example each annual DEA Water Observations frequency layer for the tile ``x11/y21``::
 
-    insert code here
+    aws s3 cp s3://dea-public-data/derivative/ga_ls_wo_fq_cyear_3/1-6-0/x11/y21/ . --recursive --exclude "*" --include "*P1Y_final_frequency.tif" --no-sign-request
+
 
 Why does Collection 3 ARD have a higher latency than Collection 2 ARD?
 ======================================================================

--- a/about/faq.rst
+++ b/about/faq.rst
@@ -3,8 +3,34 @@
  Frequently Asked Questions
 ============================
 
+How do I download data from DEA?
+================================
 
-.. based on a conversation in Slack on <2021-07-06 Tue>
+There are several options for downloading data from DEA depending on your use case:
+
+You want to download a small area of data from a specific satellite image
+-------------------------------------------------------------------------
+
+Use `DEA Maps`_ to directly export a small amount of data from the map using the :ref:`Export functionality _dea_maps_exporting`. This is the easiest method, but it is not suitable for downloading large areas of data or multiple steps (see below).
+
+You want to download all available data for a bounding box and/or time range
+----------------------------------------------------------------------------
+
+Use DEA's STAC metadata to find the data you are interested in using the `Downloading and streaming data using STAC metadata guide`_. 
+
+.. _Downloading and streaming data using STAC metadata guide:  ../Frequently_used_code/Downloading_data_with_STAC.ipynb
+
+You want to download specific files from DEA's Amazon S3 buckets
+----------------------------------------------------------------
+
+Download data directly from our `Amazon S3 buckets`_ using the AWS Command Line Interface (AWS CLI). For this you will need to know the path of the file you want to download on DEA's S3 buckets. For example, to download a single file::
+
+    aws s3 cp s3://dea-public-data/derivative/ga_ls_wo_fq_cyear_3/1-6-0/x11/y21/1992--P1Y/ga_ls_wo_fq_cyear_3_x11y21_1992--P1Y_final_frequency.tif . --no-sign-request
+
+.. _Amazon S3 buckets:  ../setup/AWS/data_and_metadata.rst
+
+To download multiple files <insert here>::
+    insert code
 
 Why does Collection 3 ARD have a higher latency than Collection 2 ARD?
 ======================================================================

--- a/about/faq.rst
+++ b/about/faq.rst
@@ -11,14 +11,14 @@ There are several options for downloading data from DEA depending on your use ca
 You want to download a small area of data from a specific satellite image
 -------------------------------------------------------------------------
 
-Use `DEA Maps`_ to directly export a small amount of data from the map using the :ref:`Export functionality <_dea_maps_exporting>`. This is the easiest method, but it is not suitable for downloading large areas of data or multiple steps (see below).
+Use `DEA Maps`_ to directly export a small amount of data from the map using the :ref:`Export functionality <dea_maps_exporting>`. This is the easiest method, but it is not suitable for downloading large areas of data or multiple steps (see below).
 
 You want to download all available data for a bounding box and/or time range
 ----------------------------------------------------------------------------
 
 Use DEA's STAC metadata to find the data you are interested in using the `Downloading and streaming data using STAC metadata guide`_. 
 
-.. _Downloading and streaming data using STAC metadata guide:  ../Frequently_used_code/Downloading_data_with_STAC.ipynb
+.. _Downloading and streaming data using STAC metadata guide:  ../notebooks/Frequently_used_code/Downloading_data_with_STAC.ipynb
 
 You want to download specific files from DEA's Amazon S3 buckets
 ----------------------------------------------------------------
@@ -30,7 +30,7 @@ Download data directly from our `Amazon S3 buckets`_ using the AWS Command Line 
 .. _Amazon S3 buckets:  ../setup/AWS/data_and_metadata.rst
 
 To download multiple files::
-    
+
     insert code code
 
 Why does Collection 3 ARD have a higher latency than Collection 2 ARD?

--- a/about/faq.rst
+++ b/about/faq.rst
@@ -11,7 +11,7 @@ There are several options for downloading data from DEA depending on your use ca
 You want to download a small area of data from a specific satellite image
 -------------------------------------------------------------------------
 
-Use `DEA Maps`_ to directly export a small amount of data from the map using the :ref:`Export functionality _dea_maps_exporting`. This is the easiest method, but it is not suitable for downloading large areas of data or multiple steps (see below).
+Use `DEA Maps`_ to directly export a small amount of data from the map using the :ref:`Export functionality <_dea_maps_exporting>`. This is the easiest method, but it is not suitable for downloading large areas of data or multiple steps (see below).
 
 You want to download all available data for a bounding box and/or time range
 ----------------------------------------------------------------------------
@@ -29,8 +29,9 @@ Download data directly from our `Amazon S3 buckets`_ using the AWS Command Line 
 
 .. _Amazon S3 buckets:  ../setup/AWS/data_and_metadata.rst
 
-To download multiple files <insert here>::
-    insert code
+To download multiple files::
+    
+    insert code code
 
 Why does Collection 3 ARD have a higher latency than Collection 2 ARD?
 ======================================================================

--- a/about/faq.rst
+++ b/about/faq.rst
@@ -8,20 +8,17 @@ How do I download data from DEA?
 
 There are several options for downloading data from DEA depending on your use case:
 
-You want to download a small area of data from a specific satellite image
--------------------------------------------------------------------------
+**1) You want to download a small area of data from a specific satellite image**
 
 Use `DEA Maps`_ to directly export a small amount of data from the map using the :ref:`Export functionality <dea_maps_exporting>`. This is the easiest method, but it is not suitable for downloading large areas of data or multiple steps (see below).
 
-You want to download all available data for a bounding box and/or time range
-----------------------------------------------------------------------------
+**2) You want to download all available data for a bounding box and/or time range**
 
 Use DEA's STAC metadata to find the data you are interested in using the `Downloading and streaming data using STAC metadata guide`_. 
 
 .. _Downloading and streaming data using STAC metadata guide:  ../notebooks/Frequently_used_code/Downloading_data_with_STAC.ipynb
 
-You want to download specific files from DEA's Amazon S3 buckets
-----------------------------------------------------------------
+**3) You want to download specific files from DEA's Amazon S3 buckets**
 
 Download data directly from our `Amazon S3 buckets`_ using the AWS Command Line Interface (AWS CLI). For this you will need to know the path of the file you want to download on DEA's S3 buckets. For example, to download a single file::
 
@@ -31,7 +28,7 @@ Download data directly from our `Amazon S3 buckets`_ using the AWS Command Line 
 
 To download multiple files::
 
-    insert code code
+    insert code here
 
 Why does Collection 3 ARD have a higher latency than Collection 2 ARD?
 ======================================================================

--- a/setup/dea_maps.rst
+++ b/setup/dea_maps.rst
@@ -119,6 +119,7 @@ DEA Maps allows you to easily create print-friendly views of satellite data for 
 .. note::
    Hint: To obtain a high quality image of your map, right click on the image at the top of the print view and select ``Save image as ...``.
 
+.. _dea_maps_exporting:
 
 Exporting data
 --------------


### PR DESCRIPTION
Here's some extra instructions here on ways to download data from DEA (so that it doesn't get lost in Slack). I've included three options:
1) Use DEA Map's "Export" functionality
2) Use STAC
3) Use AWS CLI

For # 3, I've included one very basic example of downloading an individual file. However, I'd really like us to include an example of downloading multiple files, e.g. matching a certain pattern for a C3 grid cell etc. [I have this code here in a Gist](https://gist.github.com/robbibt/320b34865248c4a073fd8dbed3ec835b), but it doesn't work exactly as I hope (it only downloads one file per tile, rather than all files matching the pattern).

If anyone had a chance to write up a super simple AWS CLI example of downloading multiple files, I think it'd be a really, really valuable thing to include here (it's one of our most common stakeholder questions too).

![image](https://user-images.githubusercontent.com/17680388/182095816-14ad4a68-21ab-451b-b44c-d014e176bd2f.png)
