### PR TITLE
Bump nbconvert to address known issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Sphinx>=2,<4
 nbsphinx==0.7.1
-nbconvert<6
+nbconvert==6.5.3
 sphinx_rtd_theme
 IPython
 recommonmark


### PR DESCRIPTION
See dependabot report: https://github.com/GeoscienceAustralia/dea-docs/security/dependabot/3
We were constraining to <6. Patch is 6.5.1, subsequent two releases look like minor fixes on that...

And yet... 6.5.3 requires a newer version of jinja2, incompatible with our pinned version.