### PR TITLE
Revert to previous commit to temporarily fix bug preventing docs publication

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,31 +30,28 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           sudo apt-get install pandoc
-
       - name: Fetch notebooks
         run: |
           git clone --depth 1 https://github.com/GeoscienceAustralia/dea-notebooks.git notebooks
           cd notebooks && git checkout -b stable
-
       - name: Build docs
         run: |
           make html
 
       - name: Configure AWS credentials via OIDC
-        if: ${{ github.event_name == 'push' && github.ref_name == 'master'  }}
+        if: ${{ github.event_name != 'pull_request' }}
         uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::538673716275:role/github-actions-dea-docs
           aws-region: ap-southeast-2
 
       - name: Publish
-        if: ${{ github.event_name == 'pull_request' && github.ref_name == 'master' }}
+        if: ${{ github.event_name != 'pull_request' }}
         env:
           DISTRIBUTION_ID: ${{ secrets.DISTRIBUTION_ID }}
         run: ./.deployment/deploy.sh


### PR DESCRIPTION
The commit here appears to have prevented the docs from automatically publishing built documentation to the user guide:
https://github.com/GeoscienceAustralia/dea-docs/commit/f6233fb8da89b7d2e6be0692305f620d6af3f401

e.g. 
![image](https://github.com/GeoscienceAustralia/dea-docs/assets/17680388/af5bbbf3-9d6f-4d8a-b6e8-14314ece9f07)


This PR temporarily reverts this commit so that we can publish new DEA Notebooks material to the user guide.

This issue should be fixed in a more robust way later on.