### PR TITLE
remove AWS explorer from tech alert

### DIFF
--- a/docs/guides/tech_alerts_changelog.md
+++ b/docs/guides/tech_alerts_changelog.md
@@ -9,10 +9,10 @@
 :::{admonition} DEA system status: yellow
 :class: caution
 
-2024-01-24: The [AWS Explorer](https://explorer.dea.ga.gov.au/) and [NCI Explorer](https://explorer.nci.dea.ga.gov.au/) 
-applications are currently experiencing intermittent outages. We are investigating this issue. 
+2024-01-24: The [NCI Explorer](https://explorer.nci.dea.ga.gov.au/) 
+application is currently experiencing intermittent outages. We are investigating this issue. 
 
-See the [DEA monitoring dashboard](https://monitoring.dea.ga.gov.au/) for the current status of these systems.
+See the [DEA monitoring dashboard](https://monitoring.dea.ga.gov.au/) for the current status of this system.
 :::
 
 


### PR DESCRIPTION
AWS Explorer is now working as expected. Removing the outage notification from the tech alert. NCI explorer is still having issues, so that notification remains. 
