### PR TITLE
Changing all anchor IDs to use the format that works

### DIFF
--- a/docs/guides/about/glossary.md
+++ b/docs/guides/about/glossary.md
@@ -1,17 +1,17 @@
 # Digital Earth Australia Glossary
 
-{#acquisition}
+(acquisition)=
 ## Acquisition
 
 An image captured by a satellite sensor.
 
-{#alos}
+(alos)=
 ## Advanced Land Observing Satellite (ALOS)
 
 A Japanese satellite launched in 2006. After five years of service, the satellite lost power and ceased communication 
 with Earth, but remains in orbit.
 
-{#aster}
+(aster)=
 ## Advanced Spaceborne Thermal and Reflection radiometer (ASTER)
 
 An imaging instrument onboard Terra, the flagship satellite of NASA's Earth Observing System (EOS) launched in December 
@@ -19,7 +19,7 @@ An imaging instrument onboard Terra, the flagship satellite of NASA's Earth Obse
 
 For more information, see [NASA: ASTER.](https://asterweb.jpl.nasa.gov/)
 
-{#avhrr}
+(avhrr)=
 ## Advanced Very-High Resolution Radiometer (AVHRR)
 
 A radiation-detection sensor that can be used for remotely determining cloud cover and the surface temperature. AVHRR 
@@ -28,66 +28,66 @@ and European MetOp satellites.
 
 For more information, see [ESA: AVHRR.](https://earth.esa.int/eogateway/missions/noaa)
 
-{#aerosol-optical-depth}
+(aerosol-optical-depth)=
 ## Aerosol optical depth
 
 Aerosol optical depth is a measure of the extinction of the solar beam by dust and haze.
 
 For more information, see [NASA Earth Observatory.](https://earthobservatory.nasa.gov/global-maps/MODAL2_M_AER_OD)
 
-{#albedo}
+(albedo)=
 ## Albedo
 
 The fraction of light that a surface reflects. Albedo is measured on a scale of 0-1, with 1 indicating that all light 
 has been reflected by the surface.
 
-{#algorithm}
+(algorithm)=
 ## Algorithm
 
 In the context of remote sensing, algorithms generally specify how to determine higher-level data products from 
 lower-level source data. For example, algorithms prescribe how atmospheric temperature and moisture profiles are 
 determined from a set of radiation observations originally sensed by satellite sounding instruments.
 
-{#ancillary}
+(ancillary)=
 ## Ancillary datasets
 
 Data which enhance processing and utilisation of remote sensing instrument data. Ancillary datasets are used to assist
 in the analysis and classification of e.g. [ARD](#ard) by providing supporting data on conditions at the time of 
 satellite data acquisition, such as aerosol and water vapour concentrations. 
 
-{#aws}
+(aws)=
 ## Amazon Web Services (AWS)
 
 One of the two environments used for hosting [Digital Earth Australia](#dea). Amazon Web Services is a commercial cloud 
 computing provider. Used by Digital Earth Australia for our JupyterHub [Sandbox](#dea-sandbox) and Web Mapping Services.
 
-{#ard}
+(ard)=
 ## Analysis Ready Data (ARD)
 
 Satellite data that has been processed to a minimum set of requirements and organised into a form that allows 
 immediate analysis and interoperability through time and with other datasets.
 
-{#api}
+(api)=
 ## Application Programming Interface (API)
 
 A software intermediary that allows two applications to talk to each other. The 
 [Open Data Cube](#odc) API gives programmers full access to the capabilities of the Cube, 
 allowing query and advanced data retrieval.
 
-{#atm-corr}
+(atm-corr)=
 ## Atmospheric correction
 
 The process of removing the effects of the atmosphere on the reflectance values of images taken by satellite or 
 airborne sensors.
 
-{#agdc}
+(agdc)=
 ## Australian Geoscience Data Cube (AGDC)
 
 A collaborative prototype project between Geoscience Australia, [CSIRO](#csiro) and 
 [NCI](#nci), which aimed to  provide better public access to NASA’s extensive Landsat archive. 
 The AGDC has since been superseded by [Digital Earth Australia](#dea).
 
-{#are}
+(are)=
 ## Australian Research Environment (ARE)
 
 The ARE is an interface for using the data and software available on the [NCI](#nci). 
@@ -95,40 +95,40 @@ It is a replacement for the old [VDI](#vdi) system.
 
 For more information, see [Australian Research Environment](https://are.nci.org.au/).
 
-{#azimuth}
+(azimuth)=
 ## Azimuth
 
 The angle of an object’s position from true north.
 
-{#azimuth-exit}
+(azimuth-exit)=
 ## Azimuthal exiting (degrees)
 
 The angle between true north and the exiting direction in the slope geometry.
 
-{#azimuth-inc}
+(azimuth-inc)=
 ## Azimuthal incident (degrees)
 
 The angle between true north and the incident direction in the slope geometry.
 
-{#band}
+(band)=
 ## Band
 
 A discrete wavelength interval or range observed by a remote sensing instrument.
 
-{#barest-earth}
+(barest-earth)=
 ## Barest Earth
 
 An estimate of the spectra of the barest state (i.e. least vegetation) observed from imagery of the Australian 
 continent collected by the Landsat 5, 7, and 8 satellites.
 
-{#brdf}
+(brdf)=
 ## Bidirectional Reflectance Distribution Function (BRDF)
 
 Bidirectional reflectance distribution function is a theoretical concept that describes the relationship between light 
 and an opaque surface. It uses a target's irradiance geometry and the remote sensing system’s relative angle to the 
 target.
 
-{#brdf-albedo}
+(brdf-albedo)=
 ## Bidirectional Reflectance Distribution Function (BRDF) / Albedo Parameter
 
 The Bidirectional Reflectance Distribution Function (BRDF)/Albedo parameters provide:
@@ -137,30 +137,30 @@ The Bidirectional Reflectance Distribution Function (BRDF)/Albedo parameters pro
 
 For more information see: [NASA](https://modis.gsfc.nasa.gov/data/dataprod/mod43.php).
 
-{#cog}
+(cog)=
 ## Cloud Optimised GeoTIFF (COG)
 
 A data file format optimised for efficient workflows on the cloud and partial file access.
 
-{#collection}
+(collection)=
 ## Collection
 
 All products downstream of the rawest form of the main input data ([telemetry](#telemetry)), 
 produced sequentially and processed with consistent algorithms/code/inputs/outputs.
 
-{#c2}
+(c2)=
 ## Collection 2 (C2)
 
 Digital Earth Australia's second [collection](#collection) of Landsat data. Now superseded by 
 [Collection 3](#c3). Note that there was no DEA Collection 2 of Sentinel 2 products.
 
-{#c3}
+(c3)=
 ## Collection 3 (C3)
 
 The third [collection](#collection) of Digital Earth Australia's Landsat or Sentinel 2 data, 
 and the most up-to-date collection available.
 
-{#collection-upgrade}
+(collection-upgrade)=
 ## Collection upgrade
 
 The reproduction of the [collection](#collection), including all downstream products, with the 
@@ -168,20 +168,20 @@ initial input being the rawest form ([telemetry](#telemetry)). Collections are u
 there are fundamental changes and upgrades to the data suite that make it incompatible with the existing collection. 
 Therefore, a collection upgrade is more akin to a movie franchise reboot than a re-release.
 
-{#ceos-seo}
+(ceos-seo)=
 ## Committee on Earth Observations, Systems Engineering Office (CEOS-SEO)
 
 Established in 1984, CEOS is the primary forum for the international coordination of space-based Earth observations. 
 The SEO performs historical coverage analyses using the data archives for the Landsat, Sentinel-1, and Sentinel-2 missions.
 
-{#csiro}
+(csiro)=
 ## Commonwealth Scientific and Industrial Research Organisation (CSIRO)
 
 An Australian federal government agency responsible for scientific research.
 
 For more information, see [CSIRO](https://www.csiro.au/).
 
-{#cophub}
+(cophub)=
 ## Copernicus Australasia Regional Data Hub
 
 Copernicus Australasia is a regional hub supporting the [Copernicus Program](#cop-prog). The 
@@ -190,7 +190,7 @@ missions for the following South-East Asia and South Pacific region.
 
 For more information, see [Copernicus Australasia](https://www.copernicus.gov.au/).
 
-{#cop-prog}
+(cop-prog)=
 ## Copernicus Programme
 
 The Copernicus Programme, established in 2014, is the European Union (EU)'s Earth observation programme coordinated and 
@@ -199,13 +199,13 @@ Agencies.
 
 For more information, see [Copernicus Programme](https://www.copernicus.eu/en).
 
-{#dataset}
+(dataset)=
 ## Dataset
 
 A related set of files composed of separate elements that can be manipulated as a unit. It is an instantiation of a 
 [product](#product).
 
-{#dea}
+(dea)=
 ## Digital Earth Australia (DEA)
 
 A Program of [Geoscience Australia](#ga) that uses spatial data and images recorded by satellites 
@@ -215,7 +215,7 @@ data and makes it available to governments and industry for easy use. DEA is the
 
 For more information, see [the DEA website](https://www.dea.ga.gov.au/).
 
-{#dea-nb}
+(dea-nb)=
 ## DEA Notebooks
 
 An open-source repository containing [Jupyter notebooks](#jupyter-nb), tools and workflows for 
@@ -223,7 +223,7 @@ geospatial analysis with [Open Data Cube](#odc) and [xarray](#xarray).
 
 For more information, see [the GitHub repository](https://github.com/GeoscienceAustralia/dea-notebooks).
 
-{#dea-sandbox}
+(dea-sandbox)=
 ## DEA Sandbox
 
 The Digital Earth Australia Sandbox is a learning and analysis environment for getting started with DEA and the 
@@ -232,25 +232,25 @@ of the [Open Data Cube](#odc).
 
 For more information, see [the getting started wiki](https://github.com/GeoscienceAustralia/dea-notebooks/wiki).
 
-{#deafrica}
+(deafrica)=
 ## Digital Earth Africa (DE Africa)
 
 A sister project to Digital Earth Australia but for the African Continent.
 
 For more information, see [Digital Earth Africa](https://www.digitalearthafrica.org/).
 
-{#dynamic-range}
+(dynamic-range)=
 ## Dynamic range
 
 The range between the maximum and minimum amount of input radiant energy that an instrument can measure.
 
-{#eo}
+(eo)=
 ## Earth Observation (EO)
 
 The process of acquiring observations of the Earth's surface via remote sensing instruments. These can include 
 satellite-based observations, as well as drone or aerial images.
 
-{#etmp}
+(etmp)=
 ## Enhanced Thematic Mapper Plus (ETM+)
 
 The sensor aboard Landsat 7 that picks up solar radiation reflected by or emitted from the Earth. It is an enhanced 
@@ -258,24 +258,24 @@ version of the [Thematic Mapper](#tm).
 
 For more information, see [NASA Enhanced Thematic Mapper Plus](https://landsat.gsfc.nasa.gov/etm-plus/).
 
-{#ephemeris}
+(ephemeris)=
 ## Ephemeris
 
 A table of satellite orbital locations for specific time intervals. The ephemeris data helps characterise the 
 conditions under which remotely sensed data is collected and is commonly used to correct the sensor data before analysis.
 
-{#esa}
+(esa)=
 ## European Space Agency (ESA)
 
 The European Space Agency is a European intergovernmental collaboration focussed on the development of Europe's space 
 capability. The ESA is a partner of the [Copernicus Programme](#cop-prog).
 
-{#exiting-angle}
+(exiting-angle)=
 ## Exiting angle (degrees)
 
 The angle between a ray reflected from a surface and the line perpendicular to the surface at the point of emergence.
 
-{#final}
+(final)=
 ## Final
 
 A stage in DEA's dataset maturity lifecycle. DEA’s best quality [ARD](#ard), produced using high quality [ancillary](#ancillary) 
@@ -283,7 +283,7 @@ datasets derived from observed data.
 
 For more information, see [DEA dataset maturity](/guides/reference/dataset_maturity_guide#final).
 
-{#fc}
+(fc)=
 ## Fractional Cover (FC)
 
 Fractional Cover (FC) is a DEA product that uses an algorithm to split the landscape into three parts, or fractions;
@@ -298,14 +298,14 @@ Landsat archive since 1987.
 For more information, and for details of the methodology, see
 [DEA Fractional Cover](https://www.dea.ga.gov.au/products/dea-fractional-cover).
 
-{#gain}
+(gain)=
 ## Gain
 
 A general term used to denote an increase in signal power in transmission from one point to another, usually expressed 
 in decibels. It can also be used to represent the multiplier used to transform satellite image digital numbers to 
 measures of at-sensor radiance.
 
-{#ga}
+(ga)=
 ## Geoscience Australia (GA)
 
 Geoscience Australia is the national public-sector geoscience organisation. It is the government’s technical advisor 
@@ -314,7 +314,7 @@ on all aspects of geoscience and is the custodian of geographic and geological d
 
 For more information, see [Geoscience Australia](https://www.ga.gov.au/).
 
-{#geomedian}
+(geomedian)=
 ## Geomedian
 
 Geometric median is a robust high-dimensional statistic that maintains relationships between spectral bands, while 
@@ -324,17 +324,17 @@ The Geometric Median provides information on the general conditions of a landsca
 
 For more information, see [Geomedian](https://doi.org/10.1109/TGRS.2017.2723896).
 
-{#gee}
+(gee)=
 ## Google Earth Engine (GEE)
 
 A Google-based platform for analysis and visualisation of geospatial datasets.
 
-{#gis}
+(gis)=
 ## Geographic Information System (GIS)
 
 A system that manages and visualises spatially referenced data.
 
-{#hltc}
+(hltc)=
 ## High and Low Tide Imagery (HLTC)
 
 Previously called High and Low Tide Composites. DEA High and Low Tide Imagery is a Digital Earth Australia product 
@@ -342,18 +342,18 @@ providing cloud-free imagery mosaics of Australia's coast, estuaries and reefs a
 
 For more information, see [DEA High and Low Tide Imagery](https://www.dea.ga.gov.au/products/dea-high-low).
 
-{#hpc}
+(hpc)=
 ## High Performance Computing (HPC)
 
 The practice of aggregating computing power in a way that delivers much higher performance than one could get out of 
 a typical desktop computer or workstation in order to solve large problems in science, engineering, or business.
 
-{#incident-angle}
+(incident-angle)=
 ## Incident angle (degrees)
 
 The angle between a ray incident on a surface and the line perpendicular to the surface at the point of incidence.
 
-{#interim}
+(interim)=
 ## Interim
 
 A stage in DEA's dataset maturity lifecycle. Interim production means that one or more [ancillary](#ancillary) datasets were not 
@@ -362,7 +362,7 @@ climatological ancillaries, and [final](#final) observed ancillaries.
 
 For more information, see [DEA dataset maturity](/guides/reference/dataset_maturity_guide#interim).
 
-{#nidem}
+(nidem)=
 ## Intertidal Elevation
 
 Previously called National Intertidal Digital Elevation Model (NIDEM). A DEA product derived from DEA Intertidal 
@@ -370,7 +370,7 @@ Extents that maps the elevation of the Australian intertidal zone relative to Me
 
 For more information, see [DEA Intertidal Elevation](https://www.dea.ga.gov.au/products/dea-intertidal-elevation).
 
-{#item}
+(item)=
 ## Intertidal Extents
 
 Previously called Intertidal Extents Model (ITEM). DEA Intertidal Extents is a DEA product that maps the relative 
@@ -378,19 +378,19 @@ extent of the Australian intertidal zone at regular intervals of the observed ti
 
 For more information, see [DEA Intertidal Extents](https://www.dea.ga.gov.au/products/dea-intertidal-extents).
 
-{#jupyter-nb}      
+(jupyter-nb)=      
 ## Jupyter notebooks
 
 A computational "notebook" that allows code to be run and presented alongside explanatory documentation, figures, 
 scientific notation etc.
 
-{#jupyter-lab}
+(jupyter-lab)=
 ## JupyterLab
 
 An interactive web-based user interface for editing and running Jupyter notebooks. JupyterLab is used as an analysis 
 environment on both the [DEA Sandbox](#dea-sandbox) and the NCI's [ARE](#are).
 
-{#landsat}
+(landsat)=
 ## Landsat
 
 A joint [NASA](#nasa)/[USGS](#usgs) program of medium resolution satellites that have been collecting publicly 
@@ -398,7 +398,7 @@ available Earth observation data continuously since 1972.
 
 For more information, see [Landsat Science](https://landsat.gsfc.nasa.gov/).
 
-{#lccs}
+(lccs)=
 ## Land Cover Classification Scheme (LCCS)
 
 The Land Cover Classification Scheme was developed by the United Nations Food and Agriculture Organization to provide 
@@ -406,7 +406,7 @@ a consistent framework for the classification and mapping of land cover.
 
 For more information, see [LCCS](https://www.fao.org/land-water/land/land-governance/land-resources-planning-toolbox/category/details/en/c/1036361/).
   
-{#mad} 
+(mad)= 
 ## Median Absolute Deviation (MAD)
 
 Median Absolute Deviation, used as a form of standard deviation for the geomedians.
@@ -415,7 +415,7 @@ The Median Absolute Deviation provides information on how a landscape is changin
 
 For more information, see [MAD](https://doi.org/10.1109/IGARSS.2018.8518312).
 
-{#modis}
+(modis)=
 ## Moderate Resolution Imaging Spectroradiometer (MODIS)
 
 A sensor aboard NASA’s Terra and Aqua satellites. MODIS instruments view the entire Earth’s surface every 1-2 days, 
@@ -424,7 +424,7 @@ Earth system models which aim to accurately predict global change.
 
 For more information, see [NASA: MODIS](https://modis.gsfc.nasa.gov/about/).
 
-{#msi}
+(msi)=
 ## MultiSpectral Instrument (MSI)
 
 The MSI is carried on the Sentinel-2 satellites. Light reflected up to the MSI instrument from the Earth and its 
@@ -434,7 +434,7 @@ for the three shortwave infrared wavelengths.
 
 For more information see: [ESA missions - Sentinel-2](https://sentinel.esa.int/web/sentinel/missions/sentinel-2).
 
-{#mss}
+(mss)=
 ## Multispectral Scanner (MSS)
 
 A line-scanning instrument carried by Landsat satellites that continually scans the Earth in a 185 km swath and 
@@ -442,30 +442,30 @@ collects data over a variety of wavelengths.
 
 For more information, see [Landsat: Multispectral Scanner](https://landsat.gsfc.nasa.gov/multispectral-scanner/).
 
-{#nadir}
+(nadir)=
 ## Nadir
 
 The point of the celestial sphere that is vertically downward from the observer and directly opposite the 
 [zenith](#zenith).
 
-{#nbar}
+(nbar)=
 ## Nadir-corrected [BRDF](#brdf) Adjusted Reflectance (NBAR)
 
 Surface reflectance data that has been corrected to remove the effects of topography and angular variation using 
 bidirectional reflectance modelling.
 
-{#nbart}
+(nbart)=
 ## Nadir-corrected [BRDF](#brdf) Adjusted Reflectance with Terrain illumination correction (NBART)
 
 Surface reflectance data that has been corrected to remove the effects of topography and angular variation using 
 bidirectional reflectance modelling, as well as corrected for the effects of terrain shadow.
 
-{#nasa}
+(nasa)=
 ## National Aeronautics and Space Administration (NASA)
 
 The United States of America's federal government's civil space, aeronautics and space research agency.
 
-{#nci}
+(nci)=
 ## National Computational Infrastructure (NCI)
 
 A national facility that provides world-class, high-end computing services to Australian researchers, including those 
@@ -473,7 +473,7 @@ working in the data-intensive areas of climate and Earth system science.
 
 For more information, see [National Computational Infrastructure](https://www.nci.org.au/).
 
-{#noaa}
+(noaa)=
 ## National Oceanic and Atmospheric Administration (NOAA)
 
 A scientific agency within the United States Department of Commerce that focuses on the conditions of the oceans, 
@@ -481,23 +481,23 @@ major waterways and atmosphere.
 
 For more information, see [NOAA](https://www.noaa.gov/).
 
-{#nbr}
+(nbr)=
 ## Normalised Burn Ratio (NBR)
 
 Calculated from near-infrared ([NIR](#nir)) and short wave infrared ([SWIR](#swir)).
 
-{#ndvi} 
+(ndvi)= 
 ## Normalised Difference Vegetation Index (NDVI)
 
 Calculated from visible and near-infrared ([NIR](#nir)) light reflected by vegetation.
 
-{#nir}
+(nir)=
 ## Near Infrared (NIR)
 
 Radiation just beyond the visible light spectrum. In Landsat and Sentinel 2 Earth observation satellites, it refers to 
 radiation between 0.7 - 0.9 micrometers.
 
-{#nrt}
+(nrt)=
 ## Near real-time (NRT)
 
 A stage in DEA's dataset maturity lifecycle. NRT data is a less refined/calibrated dataset, which is available much 
@@ -505,7 +505,7 @@ sooner after satellite acquisition than standard [ARD](#ard) data.
 
 For more information, see [DEA dataset maturity](/guides/reference/dataset_maturity_guide#nrt).
 
-{#odc}
+(odc)=
 ## Open Data Cube (ODC)
 
 An open source geospatial data management and analysis software project. It is a global initiative to increase the 
@@ -517,7 +517,7 @@ geospatial raster data.
 
 For more information, see [Open Data Cube](https://www.opendatacube.org).
 
-{#oli}
+(oli)=
 ## Operational Land Imager (OLI)
 
 The Operational Land Imager is carried by the Landsat 8 satellite. It measures in the visible, near infrared 
@@ -526,7 +526,7 @@ The Operational Land Imager is carried by the Landsat 8 satellite. It measures i
 
 For more information, see [Landsat 8](https://landsat.gsfc.nasa.gov/satellites/landsat-8/).
 
-{#oli2}
+(oli2)=
 ## Operational Land Imager 2 (OLI2)
 
 The OLI-2 instrument is carried by the Landsat 9 satellite. It provides visible and near infrared / shortwave infrared 
@@ -539,7 +539,7 @@ and instrument support electronics. OLI-2 provides data for nine spectral bands 
 
 For more information, see [Landsat 9 instruments](https://landsat.gsfc.nasa.gov/satellites/landsat-9/landsat-9-instruments/).
 
-{#panchromatic}
+(panchromatic)=
 ## Panchromatic band
 
 A band that measures a wide range of light at high resolution, compared to standard multispectral bands that measure a 
@@ -548,41 +548,41 @@ metre visible bands to higher 15 metre resolution.
 
 For more information, see [Pansharpening Landsat](/notebooks/How_to_guides/Pansharpening/).
 
-{#pixel}
+(pixel)=
 ## Pixel
 
 The minimum size area on the ground detectable by a remote sensing device. The size varies depending on the type of sensor.
 
-{#pq}
+(pq)=
 ## Pixel quality (PQ)
 
 A categorical assessment of the quality of an observation at the pixel level.
 
-{#polar-orbit}
+(polar-orbit)=
 ## Polar orbit
 
 An orbit with an orbital inclination of near 90 degrees where the satellite ground track will cross both polar regions 
 once during each orbit. The term describes the near-polar orbits of a spacecraft.
 
-{#postgresql}
+(postgresql)=
 ## PostgreSQL
 
 Also known as Postgres, it is an open source object-relational database management system with an emphasis on 
 extensibility and standards compliance. It is a high performance database engine used as both a relational and document 
 database by the [Open Data Cube](#odc).
 
-{#process}
+(process)=
 ## Process
 
 The generation of some form of output as the result of a set of actions, which may include sub-processes.
 
-{#product}
+(product)=
 ## Product
 
 A categorical term applied to describe the output from a process. Typically, a product has an associated product 
 definition which contains the product description and specification.
 
-{#python}
+(python)=
 ## Python
 
 The programming language used to develop the [Open Data Cube](#odc) and most of [Digital Earth Australia](#dea). 
@@ -590,22 +590,22 @@ It is an easy-to-use language, which also provides simple access to high perform
 
 For more information, see [Python](https://www.python.org/).
 
-{#radiance}
+(radiance)=
 ## Radiance
 
 The amount of light directly detected by remote sensing instruments.
 
-{#radiometer}
+(radiometer)=
 ## Radiometer
 
 A device that detects and measures electromagnetic radiation.
 
-{#radiometric}
+(radiometric)=
 ## Radiometric
 
 Relating to, using, or measured by a [radiometer](#radiometer). The measurement of radiation.
 
-{#raster}
+(raster)=
 ## Raster data
 
 An abstraction of the real world where spatial data is expressed as a matrix of cells or [pixel](#pixel)s, with spatial 
@@ -613,46 +613,46 @@ position implicit in the ordering of the pixels. With the raster data model, spa
 into discrete units. This makes raster data particularly suitable for certain types of spatial operations 
 (e.g. overlays or area calculations). Unlike [vector data](#vector), there are no implicit topological relationships.
 
-{#raw-data}
+(raw-data)=
 ## Raw data
 
 Numerical values representing the direct observations output by a measuring instrument. The values are transmitted as 
 a bit stream in the order they were obtained.
 
-{#real-time}
+(real-time)=
 ## Real time
 
 The time in which reporting on events or recording of events is simultaneous with the events. For example, the real 
 time of a satellite is the time in which it simultaneously reports its environment as it encounters it.
 
-{#reflectance}
+(reflectance)=
 ## Reflectance
 
 The measure of the proportion of light or other radiation striking a surface which is reflected off it.
 
-{#relative-azimuth}
+(relative-azimuth)=
 ## Relative azimuth (degrees)
 
 The relative [azimuth](#azimuth) angle between the sun and view directions.
 
-{#relative-slope}
+(relative-slope)=
 ## Relative slope (degrees)
 
 The relative [azimuth](#azimuth) angle between the incident and exiting directions in the slope geometry.
 
-{#remote-sensing}
+(remote-sensing)=
 ## Remote sensing
 
 The measurement or acquisition of information about some property of an object or phenomenon, by a recording device 
 that is not in physical or intimate contact with the object or phenomenon under study.
 
-{#resampling}
+(resampling)=
 ## Resampling
 
 Modifying the geometry of an image, which may be from either a remotely sensed or map data source. This process 
 usually involves rectification and/or registration.
 
-{#resolution}
+(resolution)=
 ## Resolution
 
 A measure of the amount of detail that can be seen in an image; i.e. the size of the smallest object recognisable using
@@ -661,36 +661,36 @@ the detector.
 In remotely sensed imagery, resolution is significant in four measurement dimensions: spectral, spatial, radiometric 
 and temporal.
 
-{#satellite-azimuth}
+(satellite-azimuth)=
 ## Satellite azimuth (degrees)
 
 The angle of the satellite’s position from true north; i.e. the angle between true north and a vertical circle passing 
 through the satellite and the point being imaged on Earth.
 
-{#satellite-zenith}
+(satellite-zenith)=
 ## Satellite view or satellite zenith (degrees)
 
 The angle between the zenith and the satellite.
 
-{#saturation}
+(saturation)=
 ## Saturation
 
 The intensity of a colour. A highly saturated colour is vivid and brilliant. To dull a colour and decrease its 
 saturation, add small amounts of its complement, making it closer to grey.
 
-{#scene}
+(scene)=
 ## Scene
 
 A defined portion of the continuous strips of data collected by satellites. Satellite data is broken up into scenes 
 for ease in handling and cataloguing.
 
-{#ssh}
+(ssh)=
 ## Secure Shell (SSH)
 
 SSH or Secure Shell is a means to access remote computers using a text based terminal interface. It comes build in 
 with Linux, but requires additional software to use it from Windows computers.
 
-{#sentinel}
+(sentinel)=
 ## Sentinel
 
 A program of satellites from Europe that collect publicly available Earth observation data. Each satellite has a 
@@ -699,64 +699,64 @@ change, emergency management and security.
 
 For more information, see [Copernicus: Discover our satellites](https://www.copernicus.eu/en/about-copernicus/infrastructure-overview/discover-our-satellites).
 
-{#swir}
+(swir)=
 ## Short-Wave Infrared (SWIR)
 
 Radiation beyond the visible light spectrum. In Landsat and Sentinel 2 Earth observation satellites, it refers to 
 radiation between 1.5 - 2.4 micrometers.
 
-{#solar-azimuth}
+(solar-azimuth)=
 ## Solar azimuth (degrees)
 
 The angle of the sun’s position from true north; i.e. the angle between true north and a vertical circle passing 
 through the sun and the point being imaged on Earth.
 
-{#solar-irradiance}
+(solar-irradiance)=
 ## Solar irradiance
 
 The solar irradiance is the output of light energy from the entire disk of the Sun, measured at the Earth.
 
-{#solar-zenith}
+(solar-zenith)=
 ## Solar zenith (degrees)
 
 The angle between the [zenith](#zenith) and the centre of the sun’s disc.
 
-{#solar-zenith-angle}
+(solar-zenith-angle)=
 ## Solar Zenith Angle (SZA)
 
 The angle between the local [zenith](#zenith) (i.e. directly above the point on the ground) and the line of sight from 
 that point to the sun.
 
-{#spatial-res}
+(spatial-res)=
 ## Spatial resolution
 
 The area on the ground that an imaging system, such as a satellite sensor, can distinguish.
 
 See also [resolution](#resolution).
 
-{#spectral-response}
+(spectral-response)=
 ## Spectral response
 
 The ratio of the relative amplitude of the response of a detector and the frequency of incident electromagnetic radiation.
 
-{#spectrometer}
+(spectrometer)=
 ## Spectrometer
 
 An optical instrument that splits the light received from an object into its component wavelengths by means of a 
 diffraction grating, and then measures the amplitudes of the individual wavelengths.
 
-{#sun-sync-orbit}
+(sun-sync-orbit)=
 ## Sun-synchronous orbit
 
 An orbit in which a satellite is always in the same position with respect to the rotating Earth at the same time of day.
 
-{#surface-reflectance}
+(surface-reflectance)=
 ## Surface reflectance
 
 The fraction of incoming solar radiation that is reflected from Earth's surface for specific incident or viewing 
 cases (directional, conical, and hemispherical cases).
 
-{#sar}
+(sar)=
 ## Synthetic Aperture Radar (SAR)
 
 An imaging radar mounted on an instant moving platform. The signal is responsive to surface characteristics like 
@@ -764,13 +764,13 @@ structure and moisture.
 
 For more information, see: [NASA - What is Synthetic Aperture Radar?](https://www.earthdata.nasa.gov/learn/backgrounders/what-is-sar).
 
-{#telemetry}
+(telemetry)=
 ## Telemetry
 
 The science and technology of automatic measurement and transmission of data by wire, radio or other means from 
 remote sources (e.g. space vehicles) to receiving stations for recording and analysis.
 
-{#tm}
+(tm)=
 ## Thematic Mapper (TM)
 
 An advanced, multispectral-scanning, Earth resources sensor featured on Landsat 4 and 5. TM is designed to acquire 
@@ -779,7 +779,7 @@ land use. It continuously scans the surface of the Earth, simultaneously acquiri
 
 For more information, see [NASA Thematic Mapper Plus](https://landsat.gsfc.nasa.gov/thematic-mapper/).
 
-{#thredds}
+(thredds)=
 ## Thematic Real-time Environmental Distributed Data Services (THREDDS)
 
 A National Computational Infrastructure ([NCI](#nci)) server, which is a high-performance and high-availability 
@@ -791,12 +791,12 @@ NetCDF subsetting, OGC WCS and WMS.
 
 For more information, see [NCI: Data ](https://nci.org.au/our-services/data-services).
 
-{#timedelta}
+(timedelta)=
 ## Timedelta (seconds)
 
 The time in seconds from satellite apogee (the point of orbit at which the satellite is furthest from the Earth).
 
-{#usgs}
+(usgs)=
 ## United States Geological Survey (USGS)
 
 A scientific agency of the United States government. The scientists of the USGS study the landscape of the United 
@@ -805,20 +805,20 @@ Landsat program of earth observation satellites.
 
 For more information, see [USGS](https://www.usgs.gov/).
 
-{#vector}
+(vector)=
 ## Vector data
 
 Vector data, when used in the context of spatial or map information, refers to a format where all map data is stored as 
 points, lines, and areas rather than as an image or continuous tone picture. These vector data have location and 
 attribute information associated with them.
 
-{#vdi}
+(vdi)=
 ## Virtual Desktop Infrastructure (VDI)
 
 The Virtual Desktop Infrastructure was a service offered by the [NCI](#nci) that provided a linux desktop environment 
 for scientific computing. It has been replaced by [ARE](#are).
 
-{#viirs}
+(viirs)=
 ## Visible Infrared Imaging Radiometer Suite (VIIRS)
 
 The Visible Infrared Imaging Radiometer Suite (VIIRS) is one of the key instruments onboard the NOAA-20 spacecraft, as 
@@ -827,12 +827,12 @@ cryosphere and oceans.
 
 For more information, see [Joint Polar Satellite System](https://www.nesdis.noaa.gov/our-satellites/currently-flying/joint-polar-satellite-system).
 
-{#wofl}
+(wofl)=
 ## Water Observation Feature Layer (WOFL)
 
 A [WO](#wo) observation for one point in time
 
-{#wo}
+(wo)=
 ## Water Observations (WO)
 
 Previously called Water Observations from Space. A Digital Earth Australia product that classifies satellite pixels 
@@ -840,24 +840,24 @@ into 'wet', 'dry', or 'invalid' (e.g. cloudy or a poor quality observation).
 
 For more information see [DEA Water Observations](https://www.dea.ga.gov.au/products/dea-water-observations).
 
-{#wavelength}
+(wavelength)=
 ## Wavelength
 
 The distance from crest to crest, or trough to trough, of an electromagnetic or other wave. The longer the wavelength, 
 the lower the frequency.
 
-{#wms}
+(wms)=
 ## Web Map Service (WMS)
 
 A HTTP interface for requesting geo-registered map images that can be displayed in a browser application or 
 [GIS](#gis) software system.
 
-{#wfs}
+(wfs)=
 ## Web Feature Service (WFS)
 
 An interface for querying, modifying and exchanging features or values in a database and retrieving features for use.
 
-{#wrs}
+(wrs)=
 ## World Reference System
 
 A global indexing scheme designed for the Landsat Program. It is based on nominal scene centres defined by path and 
@@ -865,19 +865,19 @@ row coordinates.
 
 For more information, see [NASA: World Reference System](https://landsat.gsfc.nasa.gov/about/the-worldwide-reference-system/).
 
-{#xarray}
+(xarray)=
 ## xarray
 
 An open source project and [Python](#python) package for working with labelled multidimensional arrays such as those 
 returned by the [Open Data Cube](#odc).
 
-{#yaml}
+(yaml)=
 ## Yet Another Markup Language (YAML)
 
 A human-readable data storage format. It is used throughout [DEA](#dea) for metadata files, product definitions and 
 other configuration files.
 
-{#zenith}
+(zenith)=
 ## Zenith
 
 The point on the celestial sphere directly above the observer, and directly opposite to [nadir](#nadir).

--- a/docs/guides/about/glossary.md
+++ b/docs/guides/about/glossary.md
@@ -52,14 +52,14 @@ determined from a set of radiation observations originally sensed by satellite s
 ## Ancillary datasets
 
 Data which enhance processing and utilisation of remote sensing instrument data. Ancillary datasets are used to assist
-in the analysis and classification of e.g. [ARD](#ard) by providing supporting data on conditions at the time of 
+in the analysis and classification of e.g. [ARD](./#ard) by providing supporting data on conditions at the time of 
 satellite data acquisition, such as aerosol and water vapour concentrations. 
 
 (aws)=
 ## Amazon Web Services (AWS)
 
-One of the two environments used for hosting [Digital Earth Australia](#dea). Amazon Web Services is a commercial cloud 
-computing provider. Used by Digital Earth Australia for our JupyterHub [Sandbox](#dea-sandbox) and Web Mapping Services.
+One of the two environments used for hosting [Digital Earth Australia](./#dea). Amazon Web Services is a commercial cloud 
+computing provider. Used by Digital Earth Australia for our JupyterHub [Sandbox](./#dea-sandbox) and Web Mapping Services.
 
 (ard)=
 ## Analysis Ready Data (ARD)
@@ -71,7 +71,7 @@ immediate analysis and interoperability through time and with other datasets.
 ## Application Programming Interface (API)
 
 A software intermediary that allows two applications to talk to each other. The 
-[Open Data Cube](#odc) API gives programmers full access to the capabilities of the Cube, 
+[Open Data Cube](./#odc) API gives programmers full access to the capabilities of the Cube, 
 allowing query and advanced data retrieval.
 
 (atm-corr)=
@@ -83,15 +83,15 @@ airborne sensors.
 (agdc)=
 ## Australian Geoscience Data Cube (AGDC)
 
-A collaborative prototype project between Geoscience Australia, [CSIRO](#csiro) and 
-[NCI](#nci), which aimed to  provide better public access to NASA’s extensive Landsat archive. 
-The AGDC has since been superseded by [Digital Earth Australia](#dea).
+A collaborative prototype project between Geoscience Australia, [CSIRO](./#csiro) and 
+[NCI](./#nci), which aimed to  provide better public access to NASA’s extensive Landsat archive. 
+The AGDC has since been superseded by [Digital Earth Australia](./#dea).
 
 (are)=
 ## Australian Research Environment (ARE)
 
-The ARE is an interface for using the data and software available on the [NCI](#nci). 
-It is a replacement for the old [VDI](#vdi) system.
+The ARE is an interface for using the data and software available on the [NCI](./#nci). 
+It is a replacement for the old [VDI](./#vdi) system.
 
 For more information, see [Australian Research Environment](https://are.nci.org.au/).
 
@@ -132,8 +132,8 @@ target.
 ## Bidirectional Reflectance Distribution Function (BRDF) / Albedo Parameter
 
 The Bidirectional Reflectance Distribution Function (BRDF)/Albedo parameters provide:
-* coefficients for mathematical functions that describe the BRDF of each pixel in the seven [MODIS](#modis) 'Land' bands (1- 7); and
-* [albedo](#albedo) measurements derived simultaneously from the BRDF for bands 1-7 as well as three broad bands (0.4-0.7, 0.7-3.0, and 0.4- 3.0 micrometers).
+* coefficients for mathematical functions that describe the BRDF of each pixel in the seven [MODIS](./#modis) 'Land' bands (1- 7); and
+* [albedo](./#albedo) measurements derived simultaneously from the BRDF for bands 1-7 as well as three broad bands (0.4-0.7, 0.7-3.0, and 0.4- 3.0 micrometers).
 
 For more information see: [NASA](https://modis.gsfc.nasa.gov/data/dataprod/mod43.php).
 
@@ -145,26 +145,26 @@ A data file format optimised for efficient workflows on the cloud and partial fi
 (collection)=
 ## Collection
 
-All products downstream of the rawest form of the main input data ([telemetry](#telemetry)), 
+All products downstream of the rawest form of the main input data ([telemetry](./#telemetry)), 
 produced sequentially and processed with consistent algorithms/code/inputs/outputs.
 
 (c2)=
 ## Collection 2 (C2)
 
-Digital Earth Australia's second [collection](#collection) of Landsat data. Now superseded by 
-[Collection 3](#c3). Note that there was no DEA Collection 2 of Sentinel 2 products.
+Digital Earth Australia's second [collection](./#collection) of Landsat data. Now superseded by 
+[Collection 3](./#c3). Note that there was no DEA Collection 2 of Sentinel 2 products.
 
 (c3)=
 ## Collection 3 (C3)
 
-The third [collection](#collection) of Digital Earth Australia's Landsat or Sentinel 2 data, 
+The third [collection](./#collection) of Digital Earth Australia's Landsat or Sentinel 2 data, 
 and the most up-to-date collection available.
 
 (collection-upgrade)=
 ## Collection upgrade
 
-The reproduction of the [collection](#collection), including all downstream products, with the 
-initial input being the rawest form ([telemetry](#telemetry)). Collections are updated when 
+The reproduction of the [collection](./#collection), including all downstream products, with the 
+initial input being the rawest form ([telemetry](./#telemetry)). Collections are updated when 
 there are fundamental changes and upgrades to the data suite that make it incompatible with the existing collection. 
 Therefore, a collection upgrade is more akin to a movie franchise reboot than a re-release.
 
@@ -184,7 +184,7 @@ For more information, see [CSIRO](https://www.csiro.au/).
 (cophub)=
 ## Copernicus Australasia Regional Data Hub
 
-Copernicus Australasia is a regional hub supporting the [Copernicus Program](#cop-prog). The 
+Copernicus Australasia is a regional hub supporting the [Copernicus Program](./#cop-prog). The 
 Copernicus Australasia Regional Data Hub provides free and open access to data from Europe's Sentinel satellite
 missions for the following South-East Asia and South Pacific region.
 
@@ -203,23 +203,23 @@ For more information, see [Copernicus Programme](https://www.copernicus.eu/en).
 ## Dataset
 
 A related set of files composed of separate elements that can be manipulated as a unit. It is an instantiation of a 
-[product](#product).
+[product](./#product).
 
 (dea)=
 ## Digital Earth Australia (DEA)
 
-A Program of [Geoscience Australia](#ga) that uses spatial data and images recorded by satellites 
+A Program of [Geoscience Australia](./#ga) that uses spatial data and images recorded by satellites 
 orbiting our planet to detect physical changes across Australia. DEA prepares these vast volumes of Earth observation 
 data and makes it available to governments and industry for easy use. DEA is the Australian implementation of the 
-[Open Data Cube](#odc).
+[Open Data Cube](./#odc).
 
 For more information, see [the DEA website](https://www.dea.ga.gov.au/).
 
 (dea-nb)=
 ## DEA Notebooks
 
-An open-source repository containing [Jupyter notebooks](#jupyter-nb), tools and workflows for 
-geospatial analysis with [Open Data Cube](#odc) and [xarray](#xarray).
+An open-source repository containing [Jupyter notebooks](./#jupyter-nb), tools and workflows for 
+geospatial analysis with [Open Data Cube](./#odc) and [xarray](./#xarray).
 
 For more information, see [the GitHub repository](https://github.com/GeoscienceAustralia/dea-notebooks).
 
@@ -227,8 +227,8 @@ For more information, see [the GitHub repository](https://github.com/GeoscienceA
 ## DEA Sandbox
 
 The Digital Earth Australia Sandbox is a learning and analysis environment for getting started with DEA and the 
-[Open Data Cube](#odc). It includes sample data and [Jupyter notebooks](#jupyter-nb) that demonstrate the capability 
-of the [Open Data Cube](#odc).
+[Open Data Cube](./#odc). It includes sample data and [Jupyter notebooks](./#jupyter-nb) that demonstrate the capability 
+of the [Open Data Cube](./#odc).
 
 For more information, see [the getting started wiki](https://github.com/GeoscienceAustralia/dea-notebooks/wiki).
 
@@ -254,7 +254,7 @@ satellite-based observations, as well as drone or aerial images.
 ## Enhanced Thematic Mapper Plus (ETM+)
 
 The sensor aboard Landsat 7 that picks up solar radiation reflected by or emitted from the Earth. It is an enhanced 
-version of the [Thematic Mapper](#tm).
+version of the [Thematic Mapper](./#tm).
 
 For more information, see [NASA Enhanced Thematic Mapper Plus](https://landsat.gsfc.nasa.gov/etm-plus/).
 
@@ -268,7 +268,7 @@ conditions under which remotely sensed data is collected and is commonly used to
 ## European Space Agency (ESA)
 
 The European Space Agency is a European intergovernmental collaboration focussed on the development of Europe's space 
-capability. The ESA is a partner of the [Copernicus Programme](#cop-prog).
+capability. The ESA is a partner of the [Copernicus Programme](./#cop-prog).
 
 (exiting-angle)=
 ## Exiting angle (degrees)
@@ -278,7 +278,7 @@ The angle between a ray reflected from a surface and the line perpendicular to t
 (final)=
 ## Final
 
-A stage in DEA's dataset maturity lifecycle. DEA’s best quality [ARD](#ard), produced using high quality [ancillary](#ancillary) 
+A stage in DEA's dataset maturity lifecycle. DEA’s best quality [ARD](./#ard), produced using high quality [ancillary](./#ancillary) 
 datasets derived from observed data.
 
 For more information, see [DEA dataset maturity](/guides/reference/dataset_maturity_guide#final).
@@ -310,7 +310,7 @@ measures of at-sensor radiance.
 
 Geoscience Australia is the national public-sector geoscience organisation. It is the government’s technical advisor 
 on all aspects of geoscience and is the custodian of geographic and geological data.
-[Digital Earth Australia](#dea) is a program of Geoscience Australia.
+[Digital Earth Australia](./#dea) is a program of Geoscience Australia.
 
 For more information, see [Geoscience Australia](https://www.ga.gov.au/).
 
@@ -356,9 +356,9 @@ The angle between a ray incident on a surface and the line perpendicular to the 
 (interim)=
 ## Interim
 
-A stage in DEA's dataset maturity lifecycle. Interim production means that one or more [ancillary](#ancillary) datasets were not 
-available at the time of production, and the dataset has instead been corrected using a combination of [NRT](#nrt) 
-climatological ancillaries, and [final](#final) observed ancillaries.
+A stage in DEA's dataset maturity lifecycle. Interim production means that one or more [ancillary](./#ancillary) datasets were not 
+available at the time of production, and the dataset has instead been corrected using a combination of [NRT](./#nrt) 
+climatological ancillaries, and [final](./#final) observed ancillaries.
 
 For more information, see [DEA dataset maturity](/guides/reference/dataset_maturity_guide#interim).
 
@@ -388,12 +388,12 @@ scientific notation etc.
 ## JupyterLab
 
 An interactive web-based user interface for editing and running Jupyter notebooks. JupyterLab is used as an analysis 
-environment on both the [DEA Sandbox](#dea-sandbox) and the NCI's [ARE](#are).
+environment on both the [DEA Sandbox](./#dea-sandbox) and the NCI's [ARE](./#are).
 
 (landsat)=
 ## Landsat
 
-A joint [NASA](#nasa)/[USGS](#usgs) program of medium resolution satellites that have been collecting publicly 
+A joint [NASA](./#nasa)/[USGS](./#usgs) program of medium resolution satellites that have been collecting publicly 
 available Earth observation data continuously since 1972.
 
 For more information, see [Landsat Science](https://landsat.gsfc.nasa.gov/).
@@ -446,16 +446,16 @@ For more information, see [Landsat: Multispectral Scanner](https://landsat.gsfc.
 ## Nadir
 
 The point of the celestial sphere that is vertically downward from the observer and directly opposite the 
-[zenith](#zenith).
+[zenith](./#zenith).
 
 (nbar)=
-## Nadir-corrected [BRDF](#brdf) Adjusted Reflectance (NBAR)
+## Nadir-corrected [BRDF](./#brdf) Adjusted Reflectance (NBAR)
 
 Surface reflectance data that has been corrected to remove the effects of topography and angular variation using 
 bidirectional reflectance modelling.
 
 (nbart)=
-## Nadir-corrected [BRDF](#brdf) Adjusted Reflectance with Terrain illumination correction (NBART)
+## Nadir-corrected [BRDF](./#brdf) Adjusted Reflectance with Terrain illumination correction (NBART)
 
 Surface reflectance data that has been corrected to remove the effects of topography and angular variation using 
 bidirectional reflectance modelling, as well as corrected for the effects of terrain shadow.
@@ -484,12 +484,12 @@ For more information, see [NOAA](https://www.noaa.gov/).
 (nbr)=
 ## Normalised Burn Ratio (NBR)
 
-Calculated from near-infrared ([NIR](#nir)) and short wave infrared ([SWIR](#swir)).
+Calculated from near-infrared ([NIR](./#nir)) and short wave infrared ([SWIR](./#swir)).
 
 (ndvi)= 
 ## Normalised Difference Vegetation Index (NDVI)
 
-Calculated from visible and near-infrared ([NIR](#nir)) light reflected by vegetation.
+Calculated from visible and near-infrared ([NIR](./#nir)) light reflected by vegetation.
 
 (nir)=
 ## Near Infrared (NIR)
@@ -501,7 +501,7 @@ radiation between 0.7 - 0.9 micrometers.
 ## Near real-time (NRT)
 
 A stage in DEA's dataset maturity lifecycle. NRT data is a less refined/calibrated dataset, which is available much 
-sooner after satellite acquisition than standard [ARD](#ard) data.
+sooner after satellite acquisition than standard [ARD](./#ard) data.
 
 For more information, see [DEA dataset maturity](/guides/reference/dataset_maturity_guide#nrt).
 
@@ -512,7 +512,7 @@ An open source geospatial data management and analysis software project. It is a
 value and use of satellite data by providing users with access to free and open data management technologies and 
 analysis platforms.
 
-At its core, ODC is a set of Python libraries and a [PostgreSQL](#postgresql) database that allows you to work with 
+At its core, ODC is a set of Python libraries and a [PostgreSQL](./#postgresql) database that allows you to work with 
 geospatial raster data.
 
 For more information, see [Open Data Cube](https://www.opendatacube.org).
@@ -521,8 +521,8 @@ For more information, see [Open Data Cube](https://www.opendatacube.org).
 ## Operational Land Imager (OLI)
 
 The Operational Land Imager is carried by the Landsat 8 satellite. It measures in the visible, near infrared 
-[NIR](#nir), and short wave infrared [SWIR](#swir) portions of the spectrum. Its images have 15-meter (49 ft.) 
-[panchromatic](#panchromatic) and 30-meter multi-spectral spatial resolutions along a 185 km(115 miles) wide swath.
+[NIR](./#nir), and short wave infrared [SWIR](./#swir) portions of the spectrum. Its images have 15-meter (49 ft.) 
+[panchromatic](./#panchromatic) and 30-meter multi-spectral spatial resolutions along a 185 km(115 miles) wide swath.
 
 For more information, see [Landsat 8](https://landsat.gsfc.nasa.gov/satellites/landsat-8/).
 
@@ -530,7 +530,7 @@ For more information, see [Landsat 8](https://landsat.gsfc.nasa.gov/satellites/l
 ## Operational Land Imager 2 (OLI2)
 
 The OLI-2 instrument is carried by the Landsat 9 satellite. It provides visible and near infrared / shortwave infrared 
-(VNIR/[SWIR](#swir)) imagery consistent with previous Landsat spectral, spatial, radiometric and geometric qualities.
+(VNIR/[SWIR](./#swir)) imagery consistent with previous Landsat spectral, spatial, radiometric and geometric qualities.
 
 The OLI-2 instrument includes an optical telescope, Focal Plane Array / Focal Plane Electronics, calibration hardware, 
 and instrument support electronics. OLI-2 provides data for nine spectral bands with a maximum ground sampling distance 
@@ -569,7 +569,7 @@ once during each orbit. The term describes the near-polar orbits of a spacecraft
 
 Also known as Postgres, it is an open source object-relational database management system with an emphasis on 
 extensibility and standards compliance. It is a high performance database engine used as both a relational and document 
-database by the [Open Data Cube](#odc).
+database by the [Open Data Cube](./#odc).
 
 (process)=
 ## Process
@@ -585,7 +585,7 @@ definition which contains the product description and specification.
 (python)=
 ## Python
 
-The programming language used to develop the [Open Data Cube](#odc) and most of [Digital Earth Australia](#dea). 
+The programming language used to develop the [Open Data Cube](./#odc) and most of [Digital Earth Australia](./#dea). 
 It is an easy-to-use language, which also provides simple access to high performance processing capabilities.
 
 For more information, see [Python](https://www.python.org/).
@@ -603,15 +603,15 @@ A device that detects and measures electromagnetic radiation.
 (radiometric)=
 ## Radiometric
 
-Relating to, using, or measured by a [radiometer](#radiometer). The measurement of radiation.
+Relating to, using, or measured by a [radiometer](./#radiometer). The measurement of radiation.
 
 (raster)=
 ## Raster data
 
-An abstraction of the real world where spatial data is expressed as a matrix of cells or [pixel](#pixel)s, with spatial 
+An abstraction of the real world where spatial data is expressed as a matrix of cells or [pixel](./#pixel)s, with spatial 
 position implicit in the ordering of the pixels. With the raster data model, spatial data is not continuous but divided 
 into discrete units. This makes raster data particularly suitable for certain types of spatial operations 
-(e.g. overlays or area calculations). Unlike [vector data](#vector), there are no implicit topological relationships.
+(e.g. overlays or area calculations). Unlike [vector data](./#vector), there are no implicit topological relationships.
 
 (raw-data)=
 ## Raw data
@@ -633,12 +633,12 @@ The measure of the proportion of light or other radiation striking a surface whi
 (relative-azimuth)=
 ## Relative azimuth (degrees)
 
-The relative [azimuth](#azimuth) angle between the sun and view directions.
+The relative [azimuth](./#azimuth) angle between the sun and view directions.
 
 (relative-slope)=
 ## Relative slope (degrees)
 
-The relative [azimuth](#azimuth) angle between the incident and exiting directions in the slope geometry.
+The relative [azimuth](./#azimuth) angle between the incident and exiting directions in the slope geometry.
 
 (remote-sensing)=
 ## Remote sensing
@@ -719,12 +719,12 @@ The solar irradiance is the output of light energy from the entire disk of the S
 (solar-zenith)=
 ## Solar zenith (degrees)
 
-The angle between the [zenith](#zenith) and the centre of the sun’s disc.
+The angle between the [zenith](./#zenith) and the centre of the sun’s disc.
 
 (solar-zenith-angle)=
 ## Solar Zenith Angle (SZA)
 
-The angle between the local [zenith](#zenith) (i.e. directly above the point on the ground) and the line of sight from 
+The angle between the local [zenith](./#zenith) (i.e. directly above the point on the ground) and the line of sight from 
 that point to the sun.
 
 (spatial-res)=
@@ -732,7 +732,7 @@ that point to the sun.
 
 The area on the ground that an imaging system, such as a satellite sensor, can distinguish.
 
-See also [resolution](#resolution).
+See also [resolution](./#resolution).
 
 (spectral-response)=
 ## Spectral response
@@ -782,7 +782,7 @@ For more information, see [NASA Thematic Mapper Plus](https://landsat.gsfc.nasa.
 (thredds)=
 ## Thematic Real-time Environmental Distributed Data Services (THREDDS)
 
-A National Computational Infrastructure ([NCI](#nci)) server, which is a high-performance and high-availability 
+A National Computational Infrastructure ([NCI](./#nci)) server, which is a high-performance and high-availability 
 installation of Unidata's Thematic Real-time Environmental Distributed Data Services (THREDDS).
 
 THREDDS serves many of NCI’s open data collections at the file level, as well as some aggregations. It provides many 
@@ -800,7 +800,7 @@ The time in seconds from satellite apogee (the point of orbit at which the satel
 ## United States Geological Survey (USGS)
 
 A scientific agency of the United States government. The scientists of the USGS study the landscape of the United 
-States, its natural resources, and the natural hazards that threaten it. The USGS and [NASA](#nasa) jointly run the 
+States, its natural resources, and the natural hazards that threaten it. The USGS and [NASA](./#nasa) jointly run the 
 Landsat program of earth observation satellites.
 
 For more information, see [USGS](https://www.usgs.gov/).
@@ -815,8 +815,8 @@ attribute information associated with them.
 (vdi)=
 ## Virtual Desktop Infrastructure (VDI)
 
-The Virtual Desktop Infrastructure was a service offered by the [NCI](#nci) that provided a linux desktop environment 
-for scientific computing. It has been replaced by [ARE](#are).
+The Virtual Desktop Infrastructure was a service offered by the [NCI](./#nci) that provided a linux desktop environment 
+for scientific computing. It has been replaced by [ARE](./#are).
 
 (viirs)=
 ## Visible Infrared Imaging Radiometer Suite (VIIRS)
@@ -830,7 +830,7 @@ For more information, see [Joint Polar Satellite System](https://www.nesdis.noaa
 (wofl)=
 ## Water Observation Feature Layer (WOFL)
 
-A [WO](#wo) observation for one point in time
+A [WO](./#wo) observation for one point in time
 
 (wo)=
 ## Water Observations (WO)
@@ -850,7 +850,7 @@ the lower the frequency.
 ## Web Map Service (WMS)
 
 A HTTP interface for requesting geo-registered map images that can be displayed in a browser application or 
-[GIS](#gis) software system.
+[GIS](./#gis) software system.
 
 (wfs)=
 ## Web Feature Service (WFS)
@@ -868,16 +868,16 @@ For more information, see [NASA: World Reference System](https://landsat.gsfc.na
 (xarray)=
 ## xarray
 
-An open source project and [Python](#python) package for working with labelled multidimensional arrays such as those 
-returned by the [Open Data Cube](#odc).
+An open source project and [Python](./#python) package for working with labelled multidimensional arrays such as those 
+returned by the [Open Data Cube](./#odc).
 
 (yaml)=
 ## Yet Another Markup Language (YAML)
 
-A human-readable data storage format. It is used throughout [DEA](#dea) for metadata files, product definitions and 
+A human-readable data storage format. It is used throughout [DEA](./#dea) for metadata files, product definitions and 
 other configuration files.
 
 (zenith)=
 ## Zenith
 
-The point on the celestial sphere directly above the observer, and directly opposite to [nadir](#nadir).
+The point on the celestial sphere directly above the observer, and directly opposite to [nadir](./#nadir).

--- a/docs/guides/reference/dataset_maturity_guide.md
+++ b/docs/guides/reference/dataset_maturity_guide.md
@@ -22,7 +22,7 @@ DEA produces ARD data to three maturity levels:
 * **Interim**
 * **Final**
 
-{#nrt}
+(nrt)=
 ### Near Real-Time (NRT)
 
 **Near Real-Time (NRT)** is a rapid ARD product produced within 48 hours of image capture. NRT 
@@ -35,7 +35,7 @@ Over the next few weeks, higher quality ancillary datasets become available desc
 atmospheric conditions at the time and location the satellite image was captured. Using these 
 ancillaries, ‘**final**’ maturity ARD is produced. This replaces the '**NRT**' or '**interim**' product (see below).  
 
-{#final}
+(final)=
 ### Final
 
 **Final** ARD is DEA’s best quality ARD, produced using high quality ancillary datasets derived 
@@ -47,7 +47,7 @@ DEA uses the following dynamic ancillary datasets to produce its **final** ARD:
 * Bidirectional reflectance distribution function ([BRDF](/guides/about/glossary/#brdf)) data from the United States Geological Survey 
 * Water Vapour from USA National Oceanographic and Atmospheric Administration
 
-{#interim}
+(interim)=
 ### Interim
 
 If high quality ancillaries required for the **final** ARD model don’t become available **within 23 days** of image capture,
@@ -105,7 +105,7 @@ dc.load(product="ga_ls8c_ard_3",
         dataset_maturity="final")
 ```
 
-{#provisional}
+(provisional)=
 ## What about provisional?
 
 The term **provisional** is used by DEA to denote products or services that have not yet passed quality control, and/or

--- a/docs/guides/reference/dataset_maturity_guide.md
+++ b/docs/guides/reference/dataset_maturity_guide.md
@@ -25,15 +25,9 @@ DEA produces ARD data to three maturity levels:
 (nrt)=
 ### Near Real-Time (NRT)
 
-**Near Real-Time (NRT)** is a rapid ARD product produced within 48 hours of image capture. NRT 
-data is corrected using existing long term climatology data, rather than observed conditions on the day of the 
-satellite capture (because these observational datasets, called [ancillaries](/guides/about/glossary/#ancillary), take a few weeks to be received by DEA). Due to the use of average
-condition data, rather than observational data to perform the corrections to produce ARD, NRT data can be published 
-quickly, however is considered to be of slightly lower quality than '**final**' ARD data.
+**Near Real-Time (NRT)** is a rapid ARD product produced within 48 hours of image capture. NRT data is corrected using existing long term climatology data, rather than observed conditions on the day of the satellite capture (because these observational datasets, called [ancillaries](/guides/about/glossary/#ancillary), take a few weeks to be received by DEA). Due to the use of average condition data, rather than observational data to perform the corrections to produce ARD, NRT data can be published quickly, however is considered to be of slightly lower quality than '**final**' ARD data.
 
-Over the next few weeks, higher quality ancillary datasets become available describing the specific 
-atmospheric conditions at the time and location the satellite image was captured. Using these 
-ancillaries, ‘**final**’ maturity ARD is produced. This replaces the '**NRT**' or '**interim**' product (see below).  
+Over the next few weeks, higher quality ancillary datasets become available describing the specific atmospheric conditions at the time and location the satellite image was captured. Using these ancillaries, ‘**final**’ maturity ARD is produced. This replaces the '**NRT**' or '**interim**' product (see below).
 
 (final)=
 ### Final
@@ -44,6 +38,7 @@ datasets of the conditions at the time of image capture and so provide our most 
 corrections. 
 
 DEA uses the following dynamic ancillary datasets to produce its **final** ARD:
+
 * Bidirectional reflectance distribution function ([BRDF](/guides/about/glossary/#brdf)) data from the United States Geological Survey 
 * Water Vapour from USA National Oceanographic and Atmospheric Administration
 
@@ -85,7 +80,7 @@ Previously, DEA produced two separate products:
 
 The user was then able to select which product they wanted to use according to their purpose. 
 It was more difficult to combine products as both NRT and the final ARD product contained data 
-for the same time step.  
+for the same time step.
 
 ## How do I load only Near Real-Time/Interim/Final data using the datacube? 
 
@@ -116,4 +111,4 @@ DEA's quality control standards for a product or service.
 **Provisional products are available for use, but should be used with appropriate caution.** See the individual product 
 or service metadata pages for information on product limitations and use. 
 
-Once a product is formally released, it is renamed to remove the provisional tag.  
+Once a product is formally released, it is renamed to remove the provisional tag.

--- a/docs/guides/tech_alerts_changelog.md
+++ b/docs/guides/tech_alerts_changelog.md
@@ -16,7 +16,7 @@ See the [DEA monitoring dashboard](https://monitoring.dea.ga.gov.au/).
 :::{admonition} DEA Sentinel-2 contiguity fix: ongoing
 :class: note
 
-See [alert dated 2024-01-10](./#20240110) for more details.
+See [alert dated 2024-01-10](#20240110) for more details.
 :::
 
 ## 2024-01-24: Water Observations and Fractional Cover Percentiles 2023 annual summaries released
@@ -24,7 +24,8 @@ See [alert dated 2024-01-10](./#20240110) for more details.
 See [DEA Water Observations Statistics (Landsat)](/data/product/dea-water-observations-statistics-landsat/?tab=history) 
 and [DEA Fractional Cover Percentiles (Landsat)](/data/product/dea-fractional-cover-percentiles-landsat/) for more information. 
 
-{#20240110}
+(20240110)=
+
 ## 2024-01-10: Sentinel-2 contiguity fix - Reprocessing commenced
 
 Reprocessing to fix the Sentinel-2 contiguity issue has commenced with expected completion in early 2024. The issue 

--- a/docs/guides/tech_alerts_changelog.md
+++ b/docs/guides/tech_alerts_changelog.md
@@ -25,7 +25,6 @@ See [DEA Water Observations Statistics (Landsat)](/data/product/dea-water-observ
 and [DEA Fractional Cover Percentiles (Landsat)](/data/product/dea-fractional-cover-percentiles-landsat/) for more information. 
 
 (20240110)=
-
 ## 2024-01-10: Sentinel-2 contiguity fix - Reprocessing commenced
 
 Reprocessing to fix the Sentinel-2 contiguity issue has commenced with expected completion in early 2024. The issue 

--- a/docs/guides/tech_alerts_changelog.md
+++ b/docs/guides/tech_alerts_changelog.md
@@ -35,7 +35,8 @@ created by ESA Level 1 anomalies (“[Striping due to lost source packets](https
 is impacting approximately 0.5% of our Sentinel-2 Analysis Ready Data (S2 ARD) between 2015 and 2023. 
 
 Affected products: 
-* ARD Sentinel-2 products (ga_s2am_ard_3, ga_s2bm_ard_3)  
+
+* ARD Sentinel-2 products (ga_s2am_ard_3, ga_s2bm_ard_3)
 
 See [DEA Tech alert email](https://communication.ga.gov.au/link/id/zzzz659df9f7f306b556Pzzzz61de67bd94bfe861/page.html) for more information. 
 Click [here](https://communication.ga.gov.au/link/id/zzzz659de7f165049054Pzzzz61de67bd94bfe861/page.html) to subscribe to DEA Tech alert emails.
@@ -43,6 +44,7 @@ Click [here](https://communication.ga.gov.au/link/id/zzzz659de7f165049054Pzzzz61
 ## 2023-11: Release of version 0.3.0 of DEA Tools
 
 Major update to the [DEA Tools Python package](https://docs.dea.ga.gov.au/notebooks/Tools/), including new tools for:
+
 * [pansharpening Landsat data](https://docs.dea.ga.gov.au/notebooks/How_to_guides/Pansharpening.html)
 * [tide modelling](https://docs.dea.ga.gov.au/notebooks/How_to_guides/Tidal_modelling.html)
 * [sunglint masking](https://docs.dea.ga.gov.au/notebooks/How_to_guides/Sunglint_masking.html)
@@ -104,20 +106,19 @@ all the DEA data was public to NCI users without any further steps.
 :::
 
 :::{dropdown} 2018-02-28: Update to `dea` environment module
-* 
 * Rename module to `dea`. Most people should now run
 
 ```bash
-
-     module use /g/data/v10/public/modules
-     module load dea
+module use /g/data/v10/public/modules
+module load dea
 ```
+
 * Include [JupyterLab](https://blog.jupyter.org/jupyterlab-is-ready-for-users-5a6f039b8906) as an alternative to Jupyter Notebooks. To use, from a shell run
 
 ```bash
-
-     jupyter-lab
+jupyter-lab
 ```
+
 * Include pre-release version 1.6 of Open Data Cube
 * Drop support for Python 2
 :::


### PR DESCRIPTION
Previously, I may have said that the anchor ID format of `{#custom-id}` is the one to use; however, it seems that this is not working on the site, so I have converted all those to this format `(custom-id)=` since this works.

I also made some minor Markdown code formatting to the Changelog file.