### PR TITLE
Added the Access tab link to the product page template

### DIFF
--- a/docs/_templates/product-v1.rst
+++ b/docs/_templates/product-v1.rst
@@ -117,7 +117,7 @@
        .. rubric:: Access the data
           :name: access-the-data
 
-       For help accessing the data, see the 'Access' tab.
+       For help accessing the data, see the `Access tab <./?tab=access>`_.
 
        .. container:: card-list icons
           :name: access-the-data-cards


### PR DESCRIPTION
On all products, on the Overview tab, the text that used to say "see the ‘Access’ tab." is now a link that goes directly to the Access tab when clicked.