### PR TITLE
Simplified NCI data

### DIFF
--- a/docs/data/archive/aquatic-surface-reflectance-landsat/_data.yaml
+++ b/docs/data/archive/aquatic-surface-reflectance-landsat/_data.yaml
@@ -22,9 +22,7 @@ collection:
   link: null
 doi: null
 ecat: null
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/archive/clone-of-dea-wetlands-insight-tool-qld/_data.yaml
+++ b/docs/data/archive/clone-of-dea-wetlands-insight-tool-qld/_data.yaml
@@ -22,9 +22,7 @@ collection:
   link: null
 doi: null
 ecat: null
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/archive/clone-of-dea-wetlands-insight-tool-ramsar-wetlands/_data.yaml
+++ b/docs/data/archive/clone-of-dea-wetlands-insight-tool-ramsar-wetlands/_data.yaml
@@ -23,9 +23,7 @@ collection:
   link: null
 doi: null
 ecat: null
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/archive/dea-cloud-and-cloud-shadow-mask-sentinel-2-msi/_data.yaml
+++ b/docs/data/archive/dea-cloud-and-cloud-shadow-mask-sentinel-2-msi/_data.yaml
@@ -24,9 +24,7 @@ collection:
   link: null
 doi: null
 ecat: null
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_sentinel_2_collection_1

--- a/docs/data/archive/dea-collection-3-grid-specification/_data.yaml
+++ b/docs/data/archive/dea-collection-3-grid-specification/_data.yaml
@@ -22,9 +22,7 @@ collection:
   link: null
 doi: null
 ecat: null
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/archive/dea-intertidal-suite-draft-product-testing-only/_data.yaml
+++ b/docs/data/archive/dea-intertidal-suite-draft-product-testing-only/_data.yaml
@@ -23,9 +23,7 @@ collection:
   link: null
 doi: null
 ecat: null
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_sentinel_2_collection_3

--- a/docs/data/archive/dea-land-cover-landsat-abs-draft/_data.yaml
+++ b/docs/data/archive/dea-land-cover-landsat-abs-draft/_data.yaml
@@ -22,9 +22,7 @@ collection:
   link: null
 doi: null
 ecat: null
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/archive/draft-dea-land-cover-landsat/_data.yaml
+++ b/docs/data/archive/draft-dea-land-cover-landsat/_data.yaml
@@ -22,9 +22,7 @@ collection:
   link: null
 doi: null
 ecat: null
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/archive/draft-dea-waterbodies-landsat/_data.yaml
+++ b/docs/data/archive/draft-dea-waterbodies-landsat/_data.yaml
@@ -23,9 +23,7 @@ collection:
   link: null
 doi: 10.26186/146197
 ecat: "146197"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/old-version/dea-burnt-area-landsat-2010-and-2015-2.0.0/_data.yaml
+++ b/docs/data/old-version/dea-burnt-area-landsat-2010-and-2015-2.0.0/_data.yaml
@@ -24,9 +24,7 @@ collection:
   link: null
 doi: null
 ecat: null
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - bushfire

--- a/docs/data/old-version/dea-burnt-area-vectors-sentinel-2-near-real-time-1.0.0/_data.yaml
+++ b/docs/data/old-version/dea-burnt-area-vectors-sentinel-2-near-real-time-1.0.0/_data.yaml
@@ -24,9 +24,7 @@ collection:
   link: null
 doi: null
 ecat: null
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_sentinel_2_collection_3

--- a/docs/data/old-version/dea-fractional-cover-landsat-2.2.1/_data.yaml
+++ b/docs/data/old-version/dea-fractional-cover-landsat-2.2.1/_data.yaml
@@ -27,9 +27,7 @@ collection:
   link: null
 doi: null
 ecat: "102285"
-nci:
-  name: Fractional Cover (FC25)
-  code: rs0
+nci: rs0 # Fractional Cover (FC25)
 
 tags:
   - geoscience_australia_landsat_collection_2_deprecated

--- a/docs/data/old-version/dea-fractional-cover-percentiles-landsat-2.2.1/_data.yaml
+++ b/docs/data/old-version/dea-fractional-cover-percentiles-landsat-2.2.1/_data.yaml
@@ -27,9 +27,7 @@ collection:
   link: null
 doi: null
 ecat: "120843"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_2_deprecated

--- a/docs/data/old-version/dea-mangrove-canopy-cover-landsat-2.0.2/_data.yaml
+++ b/docs/data/old-version/dea-mangrove-canopy-cover-landsat-2.0.2/_data.yaml
@@ -24,9 +24,7 @@ collection:
   link: null
 doi: null
 ecat: "135270"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_2_deprecated

--- a/docs/data/old-version/dea-pixel-quality-count-landsat-2.0.0/_data.yaml
+++ b/docs/data/old-version/dea-pixel-quality-count-landsat-2.0.0/_data.yaml
@@ -24,9 +24,7 @@ collection:
   link: null
 doi: null
 ecat: "102290"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_2_deprecated

--- a/docs/data/old-version/dea-pixel-quality-landsat-2.0.0/_data.yaml
+++ b/docs/data/old-version/dea-pixel-quality-landsat-2.0.0/_data.yaml
@@ -24,9 +24,7 @@ collection:
   link: null
 doi: null
 ecat: "102290"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_2_deprecated

--- a/docs/data/old-version/dea-surface-reflectance-geomedian-landsat-2.0.0/_data.yaml
+++ b/docs/data/old-version/dea-surface-reflectance-geomedian-landsat-2.0.0/_data.yaml
@@ -24,9 +24,7 @@ collection:
   link: null
 doi: null
 ecat: "120374"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_2_deprecated

--- a/docs/data/old-version/dea-surface-reflectance-median-absolute-deviation-landsat-2.1.0/_data.yaml
+++ b/docs/data/old-version/dea-surface-reflectance-median-absolute-deviation-landsat-2.1.0/_data.yaml
@@ -24,9 +24,7 @@ collection:
   link: null
 doi: null
 ecat: "130482"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_2_deprecated

--- a/docs/data/old-version/dea-surface-reflectance-nbar-landsat-2.0.0/_data.yaml
+++ b/docs/data/old-version/dea-surface-reflectance-nbar-landsat-2.0.0/_data.yaml
@@ -24,9 +24,7 @@ collection:
   link: null
 doi: null
 ecat: "102288"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_2_deprecated

--- a/docs/data/old-version/dea-surface-reflectance-nbar-sentinel-2-msi-1.0.0/_data.yaml
+++ b/docs/data/old-version/dea-surface-reflectance-nbar-sentinel-2-msi-1.0.0/_data.yaml
@@ -24,9 +24,7 @@ collection:
   link: null
 doi: null
 ecat: "129677"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_sentinel_2_collection_1

--- a/docs/data/old-version/dea-surface-reflectance-nbart-landsat-2.0.0/_data.yaml
+++ b/docs/data/old-version/dea-surface-reflectance-nbart-landsat-2.0.0/_data.yaml
@@ -24,9 +24,7 @@ collection:
   link: null
 doi: null
 ecat: "102291"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_2_deprecated

--- a/docs/data/old-version/dea-surface-reflectance-nbart-sentinel-2-msi-1.0.0/_data.yaml
+++ b/docs/data/old-version/dea-surface-reflectance-nbart-sentinel-2-msi-1.0.0/_data.yaml
@@ -24,9 +24,7 @@ collection:
   link: null
 doi: null
 ecat: "129684"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_sentinel_2_collection_1

--- a/docs/data/old-version/dea-water-observations-filtered-statistics-landsat-2.1.5/_data.yaml
+++ b/docs/data/old-version/dea-water-observations-filtered-statistics-landsat-2.1.5/_data.yaml
@@ -24,9 +24,7 @@ collection:
   link: null
 doi: null
 ecat: null
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_2_deprecated

--- a/docs/data/old-version/dea-water-observations-landsat-2.1.5/_data.yaml
+++ b/docs/data/old-version/dea-water-observations-landsat-2.1.5/_data.yaml
@@ -24,9 +24,7 @@ collection:
   link: null
 doi: null
 ecat: "121054"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_2_deprecated

--- a/docs/data/old-version/dea-water-observations-statistics-landsat-2.1.5/_data.yaml
+++ b/docs/data/old-version/dea-water-observations-statistics-landsat-2.1.5/_data.yaml
@@ -28,9 +28,7 @@ collection:
   link: null
 doi: null
 ecat: "121074"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_2_deprecated

--- a/docs/data/old-version/dea-wetness-percentiles-landsat-2.0.0/_data.yaml
+++ b/docs/data/old-version/dea-wetness-percentiles-landsat-2.0.0/_data.yaml
@@ -25,9 +25,7 @@ collection:
   link: null
 doi: null
 ecat: "135494"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_2_deprecated

--- a/docs/data/old-version/waterbodies-1.0.0/_data.yaml
+++ b/docs/data/old-version/waterbodies-1.0.0/_data.yaml
@@ -24,9 +24,7 @@ collection:
   link: null
 doi: null
 ecat: null
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_2_deprecated

--- a/docs/data/product/australian-geographic-reference-image/_data.yaml
+++ b/docs/data/product/australian-geographic-reference-image/_data.yaml
@@ -24,9 +24,7 @@ collection:
   link: null
 doi: null
 ecat: "72657"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - agri

--- a/docs/data/product/australian-national-spectral-database/_data.yaml
+++ b/docs/data/product/australian-national-spectral-database/_data.yaml
@@ -24,9 +24,7 @@ collection:
   link: null
 doi: null
 ecat: "145560"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - australian_remote_sensing

--- a/docs/data/product/daily-satpaths-beta/_data.yaml
+++ b/docs/data/product/daily-satpaths-beta/_data.yaml
@@ -24,9 +24,7 @@ collection:
   link: null
 doi: 10.26186/146512
 ecat: null
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - earth_observation

--- a/docs/data/product/dea-burnt-area-characteristic-layers-sentinel-2-near-real-time/_data.yaml
+++ b/docs/data/product/dea-burnt-area-characteristic-layers-sentinel-2-near-real-time/_data.yaml
@@ -25,9 +25,7 @@ collection:
   link: null
 doi: 10.26186/146449
 ecat: "146449"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_sentinel_2_collection_3

--- a/docs/data/product/dea-coastlines/_data.yaml
+++ b/docs/data/product/dea-coastlines/_data.yaml
@@ -24,9 +24,7 @@ collection:
   link: null
 doi: 10.26186/116268
 ecat: "116268"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-fractional-cover-landsat/_data.yaml
+++ b/docs/data/product/dea-fractional-cover-landsat/_data.yaml
@@ -24,9 +24,7 @@ collection:
   link: null
 doi: null
 ecat: "145498"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-fractional-cover-percentiles-landsat/_data.yaml
+++ b/docs/data/product/dea-fractional-cover-percentiles-landsat/_data.yaml
@@ -25,9 +25,7 @@ collection:
   link: null
 doi: null
 ecat: "145501"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-geometric-median-and-median-absolute-deviation-landsat/_data.yaml
+++ b/docs/data/product/dea-geometric-median-and-median-absolute-deviation-landsat/_data.yaml
@@ -27,9 +27,7 @@ collection:
   link: null
 doi: 10.26186/146261
 ecat: "146261"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-high-and-low-tide-imagery-landsat/_data.yaml
+++ b/docs/data/product/dea-high-and-low-tide-imagery-landsat/_data.yaml
@@ -26,9 +26,7 @@ collection:
   link: null
 doi: null
 ecat: "113843"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_2_deprecated

--- a/docs/data/product/dea-hotspots/_data.yaml
+++ b/docs/data/product/dea-hotspots/_data.yaml
@@ -24,9 +24,7 @@ collection:
   link: null
 doi: null
 ecat: "111881"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - bushfires

--- a/docs/data/product/dea-intertidal-elevation-landsat/_data.yaml
+++ b/docs/data/product/dea-intertidal-elevation-landsat/_data.yaml
@@ -25,9 +25,7 @@ collection:
   link: null
 doi: null
 ecat: "123678"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_2_deprecated

--- a/docs/data/product/dea-intertidal-extents-landsat/_data.yaml
+++ b/docs/data/product/dea-intertidal-extents-landsat/_data.yaml
@@ -25,9 +25,7 @@ collection:
   link: null
 doi: null
 ecat: "113842"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_2_deprecated

--- a/docs/data/product/dea-land-cover-landsat/_data.yaml
+++ b/docs/data/product/dea-land-cover-landsat/_data.yaml
@@ -25,9 +25,7 @@ collection:
   link: null
 doi: 10.26186/146090
 ecat: "146090"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - land_cover_and_land_use

--- a/docs/data/product/dea-mangrove-canopy-cover-landsat/_data.yaml
+++ b/docs/data/product/dea-mangrove-canopy-cover-landsat/_data.yaml
@@ -25,9 +25,7 @@ collection:
   link: null
 doi: null
 ecat: "145497"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-surface-reflectance-landsat-5-tm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-landsat-5-tm/_data.yaml
@@ -25,9 +25,7 @@ collection:
   link: null
 doi: null
 ecat: "130853"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-surface-reflectance-landsat-7-etm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-landsat-7-etm/_data.yaml
@@ -25,9 +25,7 @@ collection:
   link: null
 doi: null
 ecat: "132310"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-surface-reflectance-landsat-8-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-landsat-8-oli-tirs/_data.yaml
@@ -25,9 +25,7 @@ collection:
   link: null
 doi: null
 ecat: "132317"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-surface-reflectance-landsat-9-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-landsat-9-oli-tirs/_data.yaml
@@ -25,9 +25,7 @@ collection:
   link: null
 doi: 10.26186/148693
 ecat: "148693"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-5-tm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-5-tm/_data.yaml
@@ -25,9 +25,7 @@ collection:
   link: null
 doi: null
 ecat: "130853"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-7-etm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-7-etm/_data.yaml
@@ -25,9 +25,7 @@ collection:
   link: null
 doi: null
 ecat: "132310"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-8-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-8-oli-tirs/_data.yaml
@@ -25,9 +25,7 @@ collection:
   link: null
 doi: null
 ecat: "132317"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-surface-reflectance-nbar-landsat-9-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbar-landsat-9-oli-tirs/_data.yaml
@@ -25,9 +25,7 @@ collection:
   link: null
 doi: 10.26186/148693
 ecat: "148693"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-surface-reflectance-nbart-landsat-5-tm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-landsat-5-tm/_data.yaml
@@ -25,9 +25,7 @@ collection:
   link: null
 doi: null
 ecat: "130853"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-surface-reflectance-nbart-landsat-7-etm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-landsat-7-etm/_data.yaml
@@ -25,9 +25,7 @@ collection:
   link: null
 doi: null
 ecat: "132310"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-surface-reflectance-nbart-landsat-8-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-landsat-8-oli-tirs/_data.yaml
@@ -25,9 +25,7 @@ collection:
   link: null
 doi: null
 ecat: "132317"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-surface-reflectance-nbart-landsat-9-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-landsat-9-oli-tirs/_data.yaml
@@ -25,9 +25,7 @@ collection:
   link: null
 doi: 10.26186/148693
 ecat: "148693"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-surface-reflectance-nbart-sentinel-2a-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-sentinel-2a-msi/_data.yaml
@@ -25,9 +25,7 @@ collection:
   link: null
 doi: 10.26186/146571
 ecat: "146571"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_sentinel_2_collection_3

--- a/docs/data/product/dea-surface-reflectance-nbart-sentinel-2b-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-nbart-sentinel-2b-msi/_data.yaml
@@ -25,9 +25,7 @@ collection:
   link: null
 doi: 10.26186/146569
 ecat: "146569"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_sentinel_2_collection_3

--- a/docs/data/product/dea-surface-reflectance-oa-landsat-5-tm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-landsat-5-tm/_data.yaml
@@ -25,9 +25,7 @@ collection:
   link: null
 doi: null
 ecat: "130853"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-surface-reflectance-oa-landsat-7-etm/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-landsat-7-etm/_data.yaml
@@ -25,9 +25,7 @@ collection:
   link: null
 doi: null
 ecat: "132310"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-surface-reflectance-oa-landsat-8-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-landsat-8-oli-tirs/_data.yaml
@@ -25,9 +25,7 @@ collection:
   link: null
 doi: null
 ecat: "132317"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-surface-reflectance-oa-landsat-9-oli-tirs/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-landsat-9-oli-tirs/_data.yaml
@@ -25,9 +25,7 @@ collection:
   link: null
 doi: 10.26186/148693
 ecat: "148693"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-surface-reflectance-oa-sentinel-2a-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-sentinel-2a-msi/_data.yaml
@@ -25,9 +25,7 @@ collection:
   link: null
 doi: 10.26186/146568
 ecat: "146568"
-nci:
-  name: ga_s2am_ard_3
-  code: ka08
+nci: ka08
 
 tags:
   - geoscience_australia_sentinel_2_collection_3

--- a/docs/data/product/dea-surface-reflectance-oa-sentinel-2b-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-oa-sentinel-2b-msi/_data.yaml
@@ -25,9 +25,7 @@ collection:
   link: null
 doi: 10.26186/146570
 ecat: "146570"
-nci:
-  name: ga_s2bm_ard_3
-  code: ka08
+nci: ka08
 
 tags:
   - geoscience_australia_sentinel_2_collection_3

--- a/docs/data/product/dea-surface-reflectance-sentinel-2a-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-sentinel-2a-msi/_data.yaml
@@ -25,9 +25,7 @@ collection:
   link: null
 doi: 10.26186/146552
 ecat: "146552"
-nci:
-  name: ga_s2am_ard_3
-  code: ka08
+nci: ka08
 
 tags:
   - geoscience_australia_sentinel_2_collection_3

--- a/docs/data/product/dea-surface-reflectance-sentinel-2b-msi/_data.yaml
+++ b/docs/data/product/dea-surface-reflectance-sentinel-2b-msi/_data.yaml
@@ -25,9 +25,7 @@ collection:
   link: null
 doi: 10.26186/146551
 ecat: "146551"
-nci:
-  name: ga_s2bm_ard_3
-  code: ka08
+nci: ka08
 
 tags:
   - geoscience_australia_sentinel_2_collection_3

--- a/docs/data/product/dea-tasseled-cap-percentiles-landsat/_data.yaml
+++ b/docs/data/product/dea-tasseled-cap-percentiles-landsat/_data.yaml
@@ -26,9 +26,7 @@ collection:
   link: null
 doi: null
 ecat: null
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-water-observations-landsat/_data.yaml
+++ b/docs/data/product/dea-water-observations-landsat/_data.yaml
@@ -25,9 +25,7 @@ collection:
   link: null
 doi: 10.26186/146257
 ecat: "146257"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-water-observations-sentinel-2-nrt/_data.yaml
+++ b/docs/data/product/dea-water-observations-sentinel-2-nrt/_data.yaml
@@ -25,9 +25,7 @@ collection:
   link: null
 doi: 10.26186/146257
 ecat: null
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_sentinel_2_collection_3

--- a/docs/data/product/dea-water-observations-statistics-landsat/_data.yaml
+++ b/docs/data/product/dea-water-observations-statistics-landsat/_data.yaml
@@ -28,9 +28,7 @@ collection:
   link: null
 doi: null
 ecat: "146091"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-waterbodies-landsat/_data.yaml
+++ b/docs/data/product/dea-waterbodies-landsat/_data.yaml
@@ -24,9 +24,7 @@ collection:
   link: null
 doi: 10.26186/146197
 ecat: "146197"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_3

--- a/docs/data/product/dea-wetlands-insight-tool-qld/_data.yaml
+++ b/docs/data/product/dea-wetlands-insight-tool-qld/_data.yaml
@@ -24,9 +24,7 @@ collection:
   link: null
 doi: null
 ecat: "144795"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_2_deprecated

--- a/docs/data/product/dea-wetlands-insight-tool-ramsar-wetlands/_data.yaml
+++ b/docs/data/product/dea-wetlands-insight-tool-ramsar-wetlands/_data.yaml
@@ -24,9 +24,7 @@ collection:
   link: null
 doi: null
 ecat: "146165"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - geoscience_australia_landsat_collection_2_deprecated

--- a/docs/data/product/ga-land-cover-terra-modis/_data.yaml
+++ b/docs/data/product/ga-land-cover-terra-modis/_data.yaml
@@ -25,9 +25,7 @@ collection:
   link: null
 doi: null
 ecat: "83868"
-nci:
-  name: null
-  code: null
+nci: null
 
 tags:
   - drought


### PR DESCRIPTION
In the `_data.yaml` files of each product, I changed the NCI data format from ...

```yaml
nci:
  name: null
  code: null
```

to ...

```yaml
nci: null
```

There were only five product pages that contained an NCI code, and I retained that data in the new format.