### PR TITLE
Several tab links

### DIFF
--- a/docs/data/product/australian-national-spectral-database/_access.md
+++ b/docs/data/product/australian-national-spectral-database/_access.md
@@ -74,7 +74,7 @@ To access the service enter the following information:
 
 Enter information about yourself, including contact email and intended use of the database in the Description field. If your institute is not listed, please add your institute. If you are not from an institute, such as a research body or private company, please create a new institute as your name, i.e. "First Name Last Name".
 
-See the Details tab above for further information on navigation through the Specchio client and NSD.
+See the [Details tab](./?tab=details) for further information on navigation through the Specchio client and NSD.
 :::
 
 :::{dropdown} How to navigate the client

--- a/docs/data/product/dea-coastlines/_details.md
+++ b/docs/data/product/dea-coastlines/_details.md
@@ -50,7 +50,7 @@ Annual shorelines include the following attribute fields:
   - The name of the annual shoreline's Primary sediment compartment from the [Australian Coastal Sediment Compartments](https://ecat.ga.gov.au/geonetwork/srv/api/records/21a23d9a-00dd-ab19-e053-10a3070a2746) framework.
 :::
 
-To understand the `certainty` field, see the 'Quality' tab.
+To understand the `certainty` field, see the [Quality tab](./?tab=quality).
 
 :::{figure} /_files/cmi/deacl_coastlines.*
 :alt: DEA CoastLines coastline layer

--- a/docs/data/product/dea-coastlines/_faqs.md
+++ b/docs/data/product/dea-coastlines/_faqs.md
@@ -9,7 +9,7 @@ The accuracy of DEA Coastlines is lower in complex and dynamic coastal environme
 
 Cloud cover can also reduce the accuracy of the product by reducing the availability of clear satellite imagery. The data can also be limited over remote islands or reefs due to a lack of historical satellite information.
 
-For detailed information about the accuracy and limitations of DEA Coastlines, refer to the 'Quality' tab.
+For detailed information about the accuracy and limitations of DEA Coastlines, refer to the [Quality tab](./?tab=quality).
 :::
 
 :::{dropdown} DEA Coastlines 2021 dataset incorporates Landsat 9 data and uses a new tidal model. How might this affect my pre-2020 modelling?

--- a/docs/data/product/dea-fractional-cover-percentiles-landsat/_history.md
+++ b/docs/data/product/dea-fractional-cover-percentiles-landsat/_history.md
@@ -4,4 +4,4 @@
 
 Product id: `ga_ls_fc_pc_cyear_3`
 
-To access the updated product, see the [Access tab.](./?tab=access)
+To access the updated product, see the [Access tab](./?tab=access).

--- a/docs/data/product/dea-fractional-cover-percentiles-landsat/_history.md
+++ b/docs/data/product/dea-fractional-cover-percentiles-landsat/_history.md
@@ -4,4 +4,4 @@
 
 Product id: `ga_ls_fc_pc_cyear_3`
 
-To access the updated product, see the [access tab.](/data/product/dea-fractional-cover-percentiles-landsat/?tab=access)
+To access the updated product, see the [Access tab.](./?tab=access)

--- a/docs/data/product/dea-surface-reflectance-sentinel-2a-msi/_details.md
+++ b/docs/data/product/dea-surface-reflectance-sentinel-2a-msi/_details.md
@@ -18,7 +18,7 @@ The resolution is a 10/20/60 m grid based on the ESA Level 1C archive.
 *Note: DEA produces NBAR as part of the Landsat ARD. This product is **not produced as part of the Sentinel-2 ARD**.*
 
 **This Collection 3 (C3) product** and has been created by reprocessing Collection 1 (C1) and making improvements to the processing pipeline and packaging.
-See the history tab for more details.
+See the [History tab](./?tab=history) for more details.
 
 **The introduction of a maturity concept.**
 

--- a/docs/data/product/dea-surface-reflectance-sentinel-2b-msi/_details.md
+++ b/docs/data/product/dea-surface-reflectance-sentinel-2b-msi/_details.md
@@ -19,7 +19,7 @@ The resolution is a 10/20/60 m grid based on the ESA Level 1C archive.
 *Note: DEA produces NBAR as part of the Landsat ARD. This product is **not produced as part of the Sentinel-2 ARD**.*
 
 **This Collection 3 (C3) product** and has been created by reprocessing Collection 1 (C1) and making improvements to the processing pipeline and packaging.
-See the history tab for more details.
+See the [History tab](./?tab=history) for more details.
 
 **The introduction of a maturity concept.**
 

--- a/docs/data/product/dea-water-observations-statistics-landsat/_history.md
+++ b/docs/data/product/dea-water-observations-statistics-landsat/_history.md
@@ -4,4 +4,4 @@
 
 Product id: `ga_ls_wo_fq_cyear_3`
 
-To access the updated product, see the [access tab.](/data/product/dea-water-observations-statistics-landsat/?tab=access)
+To access the updated product, see the [Access tab.](./?tab=access)

--- a/docs/data/product/dea-water-observations-statistics-landsat/_history.md
+++ b/docs/data/product/dea-water-observations-statistics-landsat/_history.md
@@ -4,4 +4,4 @@
 
 Product id: `ga_ls_wo_fq_cyear_3`
 
-To access the updated product, see the [Access tab.](./?tab=access)
+To access the updated product, see the [Access tab](./?tab=access).

--- a/docs/data/product/dea-waterbodies-landsat/_faqs.md
+++ b/docs/data/product/dea-waterbodies-landsat/_faqs.md
@@ -125,7 +125,7 @@ By design, we have excluded locations where water is seen only during extreme fl
 :::{dropdown} How do I download the data?
 Individual waterbody time series can be downloaded within [National Map](https://nationalmap.gov.au/) and [DEA Maps](http://maps.dea.ga.gov.au/). Instructions on how to download individual time series can be found in the User Guide.
 
-The underlying polygon dataset containing the map of over 300,000 waterbodies across Australia can be downloaded from the 'Access' tab.
+The underlying polygon dataset containing the map of over 300,000 waterbodies across Australia can be downloaded from the [Access tab](./?tab=access).
 :::
 
 :::{dropdown} Can I load DEA Waterbodies into my GIS software?


### PR DESCRIPTION
There are several places in the content where a specific tab of a product page is mentioned, but there is no direct link to that tab. Now that we have the new tab linking functionality, I added in direct links to tabs in all the places they are referenced in the content.

For example: <https://deploy-preview-97--dea-docs.netlify.app/data/product/dea-coastlines/?tab=details>

> To understand the certainty field, see the [Quality tab](https://deploy-preview-97--dea-docs.netlify.app/data/product/dea-coastlines/?tab=quality).