### PR TITLE
Styled the 'About Digital Earth Australia' heading to make it visible…

### DIFF
--- a/docs/_static/styles/components/_showcase_panel.scss
+++ b/docs/_static/styles/components/_showcase_panel.scss
@@ -39,7 +39,6 @@
         font-size: 1.65rem;
         font-weight: bold;
         margin: 0;
-        color: white;
         line-height: 1.65;
     }
 
@@ -47,12 +46,8 @@
         flex-direction: row-reverse;
     }
 
-    &.bg-grey {
-        background-color: $bg-color-grey;
-    }
-
     &[class*="bg-gradient-"] {
-        p, dl, a, a:hover {
+        p, dl, a, a:hover, .rubric {
             color: white;
         }
     }

--- a/docs/_static/styles/components/_showcase_panel.scss
+++ b/docs/_static/styles/components/_showcase_panel.scss
@@ -35,11 +35,11 @@
         }
     }
 
-    & > div > .rubric {
+    & .rubric {
         font-size: 1.65rem;
         font-weight: bold;
         margin: 0;
-        line-height: 1.65;
+        line-height: 1.4;
         margin-bottom: 1.15rem;
     }
 
@@ -50,6 +50,12 @@
     &[class*="bg-gradient-"] {
         p, dl, a, a:hover, .rubric {
             color: white;
+        }
+    }
+
+    &.product-header {
+        .rubric {
+            margin-bottom: 0.25rem;
         }
     }
 

--- a/docs/_static/styles/components/_showcase_panel.scss
+++ b/docs/_static/styles/components/_showcase_panel.scss
@@ -40,6 +40,7 @@
         font-weight: bold;
         margin: 0;
         line-height: 1.65;
+        margin-bottom: 1.15rem;
     }
 
     &.reverse {

--- a/docs/_templates/product-v1.rst
+++ b/docs/_templates/product-v1.rst
@@ -41,7 +41,7 @@
 {{ page_title }}
 ======================================================================================================================================================
 
-.. container:: showcase-panel bg-gradient-primary
+.. container:: showcase-panel product-header bg-gradient-primary
 
    .. container::
 


### PR DESCRIPTION
… again and also added more spacing underneath these headings

Currently, this heading on the homepage is invisible:

![ksnip_20240207-135936](https://github.com/GeoscienceAustralia/dea-docs/assets/144193171/3f4a2734-aec2-4641-b0bb-ed7de12aaf35)

This fix makes it visible.