### PR TITLE
Update NCI docs text and add troubleshooting

### DIFF
--- a/docs/guides/setup/NCI/basics.rst
+++ b/docs/guides/setup/NCI/basics.rst
@@ -27,18 +27,18 @@ easier to get started with :term:`ARE`.
 .. _Gadi: https://nci.org.au/our-systems/hpc-systems/
    
 Launching JupyterLab from ARE
-=============================
+-----------------------------
 
 To launch a JupyterLab session, follow the instructions in `Starting JupyterLab
 App (ARE User Guide) <https://opus.nci.org.au/display/Help/3.1+Starting+JupyterLab+App>`_ 
-page in the NCI Help. See below for the settings required to use DEA .
+page in the NCI Help. See below for the settings required to use DEA.
 
 .. note:: To run an ARE session you must be part of a project at
    NCI with compute capacity. DEA does not currently
    provide access to such a project.
 
 Access to DEA
--------------
+*************
 
 The first time you start a JupyterLab session, there are some settings required
 to access DEA.
@@ -66,20 +66,41 @@ Set :guilabel:`Modules` to ``dea``.
    </video>
 
 
-Virtual Desktops with ARE
-=========================
+.. dropdown:: Troubleshooting: fe_sendauth: no password supplied (missing ``.pgpass`` file)
 
+   When the `dea` module is first run, a Datacube database role and ``.pgpass`` password
+   file is automatically created for you in your home directory. If you used a previous
+   version of the NCI's Virtual Desktop software (e.g. VDI, OOD), you may need to copy
+   this original ``.pgpass`` file into your new ARE home directory. If you cannot locate
+   your ``.pgpass`` file, please contact earth.observation@ga.gov.au to request your DEA
+   database account be reset.
+
+
+Launching Virtual Desktops with ARE
+-----------------------------------
+
+To launch an interactive Virtual Desktop on ARE, follow the instructions in `Connecting to
+the VDI <https://opus.nci.org.au/display/Help/2.1.+Connecting+to+the+VDI>`_ page in the 
+NCI Help. Enter the same :guilabel:`Storage`,  :guilabel:`Module directories` and
+:guilabel:`Modules` settings described above.
 
 
 Setting up Digital Earth Australia
-----------------------------------
+==================================
 
-In the terminal window run the command::
+In a terminal window on either JupyterLab or the ARE Virtual Desktop, run the command::
 
    sh /g/data/v10/public/digitalearthau/install.sh
 
 This will download the latest version of the `Digital Earth Australia notebooks
 repository <https://github.com/GeoscienceAustralia/dea-notebooks/tree/stable>`_
 into your home directory (e.g. :file:`~/dea-notebooks`).
+
+.. note:: DEA Notebooks is a large repository that will take up a large proportion of
+   of available storage space in your home directory. We recommend cloning a new 
+   copy of the repository to a location on ``/g/data/`` when possible (following the
+   `DEA notebooks guide here
+   <https://github.com/GeoscienceAustralia/dea-notebooks/wiki/Edit-a-DEA-Notebook>`_).
+
 
 

--- a/docs/guides/setup/NCI/basics.rst
+++ b/docs/guides/setup/NCI/basics.rst
@@ -12,11 +12,11 @@ Basics - JupyterLab and Virtual Desktop
 Australian Research Environment
 ===============================
 
-The easiest access to Digital Earth Australia on the NCI is via the
+The easiest way to access Digital Earth Australia on the NCI is via the
 :term:`Australian Research Environment<ARE>`. ARE has full access to the
 NCI Gadi_ :term:`HPC` Supercomputer, allowing you to run analyses using
-DEA at scale through your web browser via either an interactive Virtual 
-Desktop environment or by executing code in JupyterLab Notebooks.
+DEA at scale through your web browser via either an interactive JupyterLab
+session, or a Virtual Desktop environment.
 
 For more information on ARE see the `NCI's
 ARE User Guide <https://opus.nci.org.au/display/Help/ARE+User+Guide>`_.

--- a/docs/guides/setup/NCI/basics.rst
+++ b/docs/guides/setup/NCI/basics.rst
@@ -30,14 +30,18 @@ Launching JupyterLab from ARE
    NCI with compute capacity. DEA does not currently
    provide access to such a project.
 
+ARE allows you to run code directly using Jupyter Notebooks via their JupyterLab interface.
+
 To launch a JupyterLab session, follow the instructions in `Starting JupyterLab
 App (ARE User Guide) <https://opus.nci.org.au/display/Help/3.1+Starting+JupyterLab+App>`_ 
 page in the NCI Help. See below for the settings required to use DEA.
 
 Launching Virtual Desktops with ARE
 -----------------------------------
+Another option for accessing the NCI via ARE is to launch an interactive Virtual Desktop. This
+allows you to run your analyses in a similar interactive interface to your personal computer.
 
-To launch an interactive Virtual Desktop, follow the instructions in `Connecting to
+To launch an Virtual Desktop, follow the instructions in `Connecting to
 the VDI <https://opus.nci.org.au/display/Help/2.1.+Connecting+to+the+VDI>`_ page in the 
 NCI Help. See below for the settings required to use DEA.
 

--- a/docs/guides/setup/NCI/basics.rst
+++ b/docs/guides/setup/NCI/basics.rst
@@ -74,7 +74,7 @@ Set :guilabel:`Modules` to ``dea``.
 
 .. dropdown:: Troubleshooting: fe_sendauth: no password supplied
 
-   When the `dea` module is first run, a Datacube database role and ``.pgpass`` password
+   When the ``dea`` module is first run, a Datacube database role and ``.pgpass`` password
    file is automatically created for you in your home directory. If you used a previous
    version of the NCI's Virtual Desktop software (e.g. VDI, OOD), you may need to copy
    this original ``.pgpass`` file into your new ARE home directory. If you cannot locate

--- a/docs/guides/setup/NCI/basics.rst
+++ b/docs/guides/setup/NCI/basics.rst
@@ -13,15 +13,13 @@ Australian Research Environment
 ===============================
 
 The easiest access to Digital Earth Australia on the NCI is via the
-:term:`Australian Research Environment<ARE>`. Through your web browser you can
-access a Virtual Desktop environment or execute code in JupyterLab Notebooks.
+:term:`Australian Research Environment<ARE>`. ARE has full access to the
+NCI Gadi_ :term:`HPC` Supercomputer, allowing you to run analyses using
+DEA at scale through your web browser via either an interactive Virtual 
+Desktop environment or by executing code in JupyterLab Notebooks.
 
 For more information on ARE see the `NCI's
 ARE User Guide <https://opus.nci.org.au/display/Help/ARE+User+Guide>`_.
-
-It's also possible to use DEA on the NCI's Gadi_ :term:`HPC` Supercomputer,
-however unless you're experienced with :term:`SSH` and HPC systems, it's much
-easier to get started with :term:`ARE`.
 
 .. _Gadi: https://nci.org.au/our-systems/hpc-systems/
    
@@ -51,12 +49,20 @@ to access DEA.
 
 **Storage**
 
+To access data on the NCI's filesystem, you need to list all NCI projects containing data
+you wish to access. Most importantly, this includes the ``v10`` NCI project that contains
+files required to set up Datacube.
+
 Type `gdata/v10` into the :guilabel:`Storage` box, then use the dropdown to select other
 projects containing data you wish to access. See :ref:`nci_data_access`.
 
 .. figure:: /_files/nci/are_highlight_v10_storage_setting.png
 
 **DEA Environment**
+
+DEA provides a pre-packaged NCI environment containing all important Python packages required
+to run a Datacube analysis. To use this environment, we need to specify it when we launch a
+JupyterLab or Virtual Desktop session.
 
 Scroll down and expand :guilabel:`Advanced options...`.
 
@@ -84,6 +90,8 @@ Set :guilabel:`Modules` to ``dea``.
 
 Setting up Digital Earth Australia
 ==================================
+
+You will need to install DEA the first time you launch a session.
 
 In a terminal window on either JupyterLab or the ARE Virtual Desktop, run the command::
 

--- a/docs/guides/setup/NCI/basics.rst
+++ b/docs/guides/setup/NCI/basics.rst
@@ -82,14 +82,14 @@ Set :guilabel:`Modules` to ``dea``.
    </video>
 
 
-.. dropdown:: Troubleshooting: fe_sendauth: no password supplied
+.. dropdown:: Troubleshooting: 'fe_sendauth: no password supplied'
 
    When the ``dea`` module is first run, a Datacube database role and ``.pgpass`` password
    file is automatically created for you in your home directory. If you used a previous
    version of the NCI's Virtual Desktop software (e.g. VDI, OOD), you may need to copy
    this original ``.pgpass`` file into your new ARE home directory. If you cannot locate
-   your ``.pgpass`` file, please contact earth.observation@ga.gov.au to request your DEA
-   database account be reset.
+   your ``.pgpass`` file, please contact earth.observation@ga.gov.au to request for your
+   DEA database account to be reset.
 
 
 Setting up Digital Earth Australia
@@ -97,7 +97,7 @@ Setting up Digital Earth Australia
 
 You will need to install DEA the first time you launch a session.
 
-In a terminal window on either JupyterLab or the ARE Virtual Desktop, run the command::
+In a terminal window in either JupyterLab or the ARE Virtual Desktop, run the command::
 
    sh /g/data/v10/public/digitalearthau/install.sh
 
@@ -106,10 +106,9 @@ repository <https://github.com/GeoscienceAustralia/dea-notebooks/tree/stable>`_
 into your home directory (e.g. :file:`~/dea-notebooks`).
 
 .. note:: DEA Notebooks is a large repository that will take up a large proportion of
-   of available storage space in your home directory. We recommend cloning a new 
-   copy of the repository to a location on ``/g/data/`` when possible (following the
-   `DEA notebooks guide here
-   <https://github.com/GeoscienceAustralia/dea-notebooks/wiki/Edit-a-DEA-Notebook>`_).
+   of available storage space in your home directory. We recommend cloning a new copy 
+   of the repository to a location on ``/g/data/`` when possible. (Learn how to `clone
+   a DEA Notebook <https://github.com/GeoscienceAustralia/dea-notebooks/wiki/Edit-a-DEA-Notebook>`_.)
 
 
 

--- a/docs/guides/setup/NCI/basics.rst
+++ b/docs/guides/setup/NCI/basics.rst
@@ -39,7 +39,7 @@ page in the NCI Help. See below for the settings required to use DEA.
 Launching Virtual Desktops with ARE
 -----------------------------------
 Another option for accessing the NCI via ARE is to launch an interactive Virtual Desktop. This
-allows you to run your analyses in a similar interactive interface to your personal computer.
+allows you to run your analyses using a similar interactive interface to your personal computer.
 
 To launch an Virtual Desktop, follow the instructions in `Connecting to
 the VDI <https://opus.nci.org.au/display/Help/2.1.+Connecting+to+the+VDI>`_ page in the 

--- a/docs/guides/setup/NCI/basics.rst
+++ b/docs/guides/setup/NCI/basics.rst
@@ -23,24 +23,30 @@ It's also possible to use DEA on the NCI's Gadi_ :term:`HPC` Supercomputer,
 however unless you're experienced with :term:`SSH` and HPC systems, it's much
 easier to get started with :term:`ARE`.
 
-
 .. _Gadi: https://nci.org.au/our-systems/hpc-systems/
    
 Launching JupyterLab from ARE
 -----------------------------
 
-To launch a JupyterLab session, follow the instructions in `Starting JupyterLab
-App (ARE User Guide) <https://opus.nci.org.au/display/Help/3.1+Starting+JupyterLab+App>`_ 
-page in the NCI Help. See below for the settings required to use DEA.
-
 .. note:: To run an ARE session you must be part of a project at
    NCI with compute capacity. DEA does not currently
    provide access to such a project.
 
-Access to DEA
-*************
+To launch a JupyterLab session, follow the instructions in `Starting JupyterLab
+App (ARE User Guide) <https://opus.nci.org.au/display/Help/3.1+Starting+JupyterLab+App>`_ 
+page in the NCI Help. See below for the settings required to use DEA.
 
-The first time you start a JupyterLab session, there are some settings required
+Launching Virtual Desktops with ARE
+-----------------------------------
+
+To launch an interactive Virtual Desktop, follow the instructions in `Connecting to
+the VDI <https://opus.nci.org.au/display/Help/2.1.+Connecting+to+the+VDI>`_ page in the 
+NCI Help. See below for the settings required to use DEA.
+
+DEA access settings
+-------------------
+
+The first time you start a JupyterLab or Virtual Desktop session, there are some settings required
 to access DEA.
 
 **Storage**
@@ -66,7 +72,7 @@ Set :guilabel:`Modules` to ``dea``.
    </video>
 
 
-.. dropdown:: Troubleshooting: fe_sendauth: no password supplied (missing ``.pgpass`` file)
+.. dropdown:: Troubleshooting: fe_sendauth: no password supplied
 
    When the `dea` module is first run, a Datacube database role and ``.pgpass`` password
    file is automatically created for you in your home directory. If you used a previous
@@ -74,15 +80,6 @@ Set :guilabel:`Modules` to ``dea``.
    this original ``.pgpass`` file into your new ARE home directory. If you cannot locate
    your ``.pgpass`` file, please contact earth.observation@ga.gov.au to request your DEA
    database account be reset.
-
-
-Launching Virtual Desktops with ARE
------------------------------------
-
-To launch an interactive Virtual Desktop on ARE, follow the instructions in `Connecting to
-the VDI <https://opus.nci.org.au/display/Help/2.1.+Connecting+to+the+VDI>`_ page in the 
-NCI Help. Enter the same :guilabel:`Storage`,  :guilabel:`Module directories` and
-:guilabel:`Modules` settings described above.
 
 
 Setting up Digital Earth Australia


### PR DESCRIPTION
This PR adds a new troubleshooting section to the NCI docs capturing a common issue users have with a missing `.pgpass` file. It also documents how to launch a Virtual Desktop (not Jupyterlab instance).

Have also at least partially addressed #52 by updating some of the existing text.

<!-- Enter 'x' into the checkbox to confirm (if applicable). -->

- [x] I have spellchecked my content using Microsoft Word, Grammarly, or otherwise.
