### PR TITLE
Updating Notebooks to latest 'stable' branch

### DIFF
--- a/docs/table_of_contents.yaml
+++ b/docs/table_of_contents.yaml
@@ -179,21 +179,21 @@ entries:
 
   - file: notebooks/README
     title: DEA Notebooks
-    # subtrees:
-    #   - caption: Getting started
-    #     entries:
-    #       - file: notebooks/Beginners_guide/README # Contains its own table of contents.
-    #
-    #   - caption: Using the data products
-    #     entries:
-    #       - file: notebooks/DEA_products/README # Contains its own table of contents.
-    #       - file: notebooks/How_to_guides/README # Contains its own table of contents.
-    #       - file: notebooks/Real_world_examples/README # Contains its own table of contents.
-    #
-    #   - caption: Resources
-    #     entries:
-    #       - file: notebooks/Interactive_apps/README # Contains its own table of contents.
-    #       - file: notebooks/Tools/index # Contains its own table of contents.
+    subtrees:
+      - caption: Getting started
+        entries:
+          - file: notebooks/Beginners_guide/README # Contains its own table of contents.
+
+      - caption: Using the data products
+        entries:
+          - file: notebooks/DEA_products/README # Contains its own table of contents.
+          - file: notebooks/How_to_guides/README # Contains its own table of contents.
+          - file: notebooks/Real_world_examples/README # Contains its own table of contents.
+
+      - caption: Resources
+        entries:
+          - file: notebooks/Interactive_apps/README # Contains its own table of contents.
+          - file: notebooks/Tools/index # Contains its own table of contents.
 
   - file: tags/index
     entries:

--- a/docs/table_of_contents.yaml
+++ b/docs/table_of_contents.yaml
@@ -184,7 +184,7 @@ entries:
         entries:
           - file: notebooks/Beginners_guide/README # Contains its own table of contents.
 
-      - caption: Explore topics
+      - caption: Explore the notebooks
         entries:
           - file: notebooks/DEA_products/README # Contains its own table of contents.
           - file: notebooks/How_to_guides/README # Contains its own table of contents.

--- a/docs/table_of_contents.yaml
+++ b/docs/table_of_contents.yaml
@@ -184,7 +184,7 @@ entries:
         entries:
           - file: notebooks/Beginners_guide/README # Contains its own table of contents.
 
-      - caption: Using the data
+      - caption: Explore topics
         entries:
           - file: notebooks/DEA_products/README # Contains its own table of contents.
           - file: notebooks/How_to_guides/README # Contains its own table of contents.

--- a/docs/table_of_contents.yaml
+++ b/docs/table_of_contents.yaml
@@ -184,15 +184,15 @@ entries:
         entries:
           - file: notebooks/Beginners_guide/README # Contains its own table of contents.
 
-      - caption: Using the data products
+      - caption: Using the data
         entries:
           - file: notebooks/DEA_products/README # Contains its own table of contents.
           - file: notebooks/How_to_guides/README # Contains its own table of contents.
+          - file: notebooks/Interactive_apps/README # Contains its own table of contents.
           - file: notebooks/Real_world_examples/README # Contains its own table of contents.
 
-      - caption: Resources
+      - caption: Reference
         entries:
-          - file: notebooks/Interactive_apps/README # Contains its own table of contents.
           - file: notebooks/Tools/index # Contains its own table of contents.
 
   - file: tags/index


### PR DESCRIPTION
On the dea-notebooks repo, the 'stable' branch was updated with the latest changes. This PR will update the KH to include those latest changes. Notably, the sidebar of the Notebooks section of the KH will now include subheadings.