### PR TITLE
Add clarification to NRT timeline

### DIFF
--- a/docs/guides/reference/dataset_maturity_guide.md
+++ b/docs/guides/reference/dataset_maturity_guide.md
@@ -25,7 +25,7 @@ DEA produces ARD data to three maturity levels:
 {#nrt}
 ### Near Real-Time (NRT)
 
-**Near Real-Time (NRT)** is a rapid ARD product produced within 48 hours of image capture. NRT 
+**Near Real-Time (NRT)** is a rapid ARD product produced within 48 hours (and often less than 24 hours) of image capture. NRT 
 data is corrected using existing long term climatology data, rather than observed conditions on the day of the 
 satellite capture (because these observational datasets, called [ancillaries](/guides/about/glossary/#ancillary), take a few weeks to be received by DEA). Due to the use of average
 condition data, rather than observational data to perform the corrections to produce ARD, NRT data can be published 


### PR DESCRIPTION
Have slightly updated the words of the NRT dataset maturity guide to make it clear that we often produce NRT much faster than 48 hours. 

Happy for any wording suggestions here! I just think that if we're often producing data less than 24 hours after capture, we might as well advertise this (in a way that doesn't hold us to any firm deadline).