### PR TITLE
Removed indent from sidebar items

### DIFF
--- a/docs/_static/styles/components/_navigation_sidebar.scss
+++ b/docs/_static/styles/components/_navigation_sidebar.scss
@@ -33,6 +33,10 @@
     nav.bd-docs-nav {
         padding-right: 2px;
 
+        &.bd-links li > a {
+            padding-left: 0;
+        }
+
         .bd-links__title {
             display: none;
         }


### PR DESCRIPTION
I need a second opinion on this one -- does this look better or worse? You can compare the sidebar on the current site to the demo:

https://docs.dea.ga.gov.au/data/

https://deploy-preview-119--dea-docs.netlify.app/data/
