### PR TITLE
[skip ci] Added Tech Alerts and Changelog and DEA Sandbox to the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,7 @@
 <!-- Enter 'x' into the checkbox to confirm (if applicable). -->
 
-- [ ] I have spellchecked my content using Microsoft Word, Grammarly, or otherwise.
+* [ ] I have spellchecked my content using Microsoft Word, Grammarly, or otherwise.
+* [ ] If required, update the [DEA Tech Alerts and Changelog](TechAlertsChangelog) and the [DEA Sandbox Updates banner](SandboxUpdatesBanner).
+
+[TechAlertsChangelog]: https://github.com/GeoscienceAustralia/dea-docs/blob/main/docs/tech-alerts-changelog/_tech_alerts_changelog.md
+[SandboxUpdatesBanner]: https://bitbucket.org/geoscienceaustralia/datakube-apps/src/64c28bbf3d0e019d8940547a22f78b9bfd58d739/clusters/dea-sandbox/sandbox.yaml


### PR DESCRIPTION
<!-- Enter 'x' into the checkbox to confirm (if applicable). -->

- [x] I have spellchecked my content using Microsoft Word, Grammarly, or otherwise.

@robbibt This is to address your issue: https://github.com/GeoscienceAustralia/dea-docs/issues/117

**Here is a preview of how the PR will display:**

<!-- Enter 'x' into the checkbox to confirm (if applicable). -->

* [ ] I have spellchecked my content using Microsoft Word, Grammarly, or otherwise.
* [ ] If required, update the [DEA Tech Alerts and Changelog](TechAlertsChangelog) and the [DEA Sandbox Updates banner](SandboxUpdatesBanner).

[TechAlertsChangelog]: https://github.com/GeoscienceAustralia/dea-docs/blob/main/docs/tech-alerts-changelog/_tech_alerts_changelog.md
[SandboxUpdatesBanner]: https://bitbucket.org/geoscienceaustralia/datakube-apps/src/64c28bbf3d0e019d8940547a22f78b9bfd58d739/clusters/dea-sandbox/sandbox.yaml
