### PR TITLE
Fix for how Quality tab is blank

### DIFF
--- a/docs/data/product/dea-fractional-cover-percentiles-landsat/_details.md
+++ b/docs/data/product/dea-fractional-cover-percentiles-landsat/_details.md
@@ -103,26 +103,6 @@ DEA Water Observations are used to identify clear pixels from DEA Fractional Cov
 * Please note, no land/sea masking is applied 
 * Observation dates for given percentiles are not captured 
 
-### QA enumeration 
-
-To assist with the downstream calculation of the [DEA Mangrove Canopy Cover](/data/product/dea-mangrove-canopy-cover-landsat/) product, each pixel has an additional enumeration associated with it: 
-
-* **0** - Not enough observations to calculate percentiles (less than 3 clear and dry observations), and there is at least one observation that has been identified as wet. Defined in ODC configuration as: insufficient observations wet. 
-* **1** \- Not enough observations to calculate percentiles (less than 3 clear and dry observations), but never identified as wet. Defined in ODC configuration as: insufficient observations dry. 
-* **2** \- There are sufficient observations to compute percentiles (3 or more clear and dry observations). Defined in ODC configuration as: sufficient observations 
-
-This enumeration assists in quantifying uncertainty within the [DEA Mangrove Canopy Cover](/data/product/dea-mangrove-canopy-cover-landsat/) (see Mangrove Canopy Cover definition). 
-
-### Side car files 
-
-Collection 3 Fractional Cover Percentiles will be accompanied by the following metadata, presentation and quality assurance side car files: 
-
-* `*.odc-metadata.yaml`: EODatasets 3 compatible ODC dataset definition
-* `*.odc-proc-info.yaml`: Listing of python libraries and versions used by software to generate
-* `*.sha1`: Cryptographic hash of data to validate distributed data
-* `*.thumbnail.jpg`: Quick look thumbnail of a scaled RGB rendering of R = `bs_pc_50`, G= `pv_pc_50` and B = `npv_pc_50`
-* `*.stac-item.json`: STAC 1.0.0 STAC document 
-
 ### Temporal period 
 
 Will be calculated from the 1st of January to the 31st of December (inclusive) for every available year of DEA Landsat Collection 3 Water Observations and DEA Landsat Collection 3 Fractional Cover observations. 

--- a/docs/data/product/dea-fractional-cover-percentiles-landsat/_quality.md
+++ b/docs/data/product/dea-fractional-cover-percentiles-landsat/_quality.md
@@ -6,18 +6,33 @@
 
 To assist with the downstream calculation of the [DEA Mangrove Canopy Cover](/data/product/dea-mangrove-canopy-cover-landsat/) product, each pixel has an additional enumeration associated with it: 
 
-* **0** - Not enough observations to calculate percentiles (less than 3 clear and dry observations), and there is at least one observation that has been identified as wet. Defined in ODC configuration as: insufficient observations wet. 
-* **1** \- Not enough observations to calculate percentiles (less than 3 clear and dry observations), but never identified as wet. Defined in ODC configuration as: insufficient observations dry. 
-* **2** \- There are sufficient observations to compute percentiles (3 or more clear and dry observations). Defined in ODC configuration as: sufficient observations 
+:::{list-table}
+
+* - **0**
+  - Not enough observations to calculate percentiles (less than 3 clear and dry observations), and there is at least one observation that has been identified as wet. Defined in ODC configuration as: insufficient observations wet. 
+* - **1**
+  - Not enough observations to calculate percentiles (less than 3 clear and dry observations), but never identified as wet. Defined in ODC configuration as: insufficient observations dry. 
+* - **2**
+  - There are sufficient observations to compute percentiles (3 or more clear and dry observations). Defined in ODC configuration as: sufficient observations 
+:::
 
 This enumeration assists in quantifying uncertainty within the [DEA Mangrove Canopy Cover](/data/product/dea-mangrove-canopy-cover-landsat/) (see Mangrove Canopy Cover definition). 
 
 ### Side car files 
 
-Collection 3 Fractional Cover Percentiles will be accompanied by the following metadata, presentation and quality assurance side car files: 
+Collection 3 Fractional Cover Percentiles will be accompanied by the following metadata, presentation and quality assurance side car files:
 
-* `*.odc-metadata.yaml`: EODatasets 3 compatible ODC dataset definition
-* `*.odc-proc-info.yaml`: Listing of python libraries and versions used by software to generate
-* `*.sha1`: Cryptographic hash of data to validate distributed data
-* `*.thumbnail.jpg`: Quick look thumbnail of a scaled RGB rendering of R = `bs_pc_50`, G= `pv_pc_50` and B = `npv_pc_50`
-* `*.stac-item.json`: STAC 1.0.0 STAC document 
+:::{list-table}
+
+* - `*.odc-metadata.yaml`
+  - EODatasets 3 compatible ODC dataset definition
+* - `*.odc-proc-info.yaml`
+  - Listing of python libraries and versions used by software to generate
+* - `*.sha1`
+  - Cryptographic hash of data to validate distributed data
+* - `*.thumbnail.jpg`
+  - Quick look thumbnail of a scaled RGB rendering of R = `bs_pc_50`, G= `pv_pc_50` and B = `npv_pc_50`
+* - `*.stac-item.json`
+  - STAC 1.0.0 STAC document 
+:::
+

--- a/docs/data/product/dea-fractional-cover-percentiles-landsat/_quality.md
+++ b/docs/data/product/dea-fractional-cover-percentiles-landsat/_quality.md
@@ -1,4 +1,23 @@
 % ## Accuracy
 
-% ## Quality assurance
+## Quality assurance
 
+### QA enumeration 
+
+To assist with the downstream calculation of the [DEA Mangrove Canopy Cover](/data/product/dea-mangrove-canopy-cover-landsat/) product, each pixel has an additional enumeration associated with it: 
+
+* **0** - Not enough observations to calculate percentiles (less than 3 clear and dry observations), and there is at least one observation that has been identified as wet. Defined in ODC configuration as: insufficient observations wet. 
+* **1** \- Not enough observations to calculate percentiles (less than 3 clear and dry observations), but never identified as wet. Defined in ODC configuration as: insufficient observations dry. 
+* **2** \- There are sufficient observations to compute percentiles (3 or more clear and dry observations). Defined in ODC configuration as: sufficient observations 
+
+This enumeration assists in quantifying uncertainty within the [DEA Mangrove Canopy Cover](/data/product/dea-mangrove-canopy-cover-landsat/) (see Mangrove Canopy Cover definition). 
+
+### Side car files 
+
+Collection 3 Fractional Cover Percentiles will be accompanied by the following metadata, presentation and quality assurance side car files: 
+
+* `*.odc-metadata.yaml`: EODatasets 3 compatible ODC dataset definition
+* `*.odc-proc-info.yaml`: Listing of python libraries and versions used by software to generate
+* `*.sha1`: Cryptographic hash of data to validate distributed data
+* `*.thumbnail.jpg`: Quick look thumbnail of a scaled RGB rendering of R = `bs_pc_50`, G= `pv_pc_50` and B = `npv_pc_50`
+* `*.stac-item.json`: STAC 1.0.0 STAC document 


### PR DESCRIPTION
Moved some QA-related content from the Details tab to the Quality tab of DEA Fractional Cover Percentiles (Landsat).

