### PR TITLE
Removed version number from conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,6 @@ environment = {
 project = "DEA Knowledge Hub"
 copyright = f"{utilities.current_year()}, Geoscience Australia"
 author = "Geoscience Australia"
-version = "0.1"
 
 html_static_path = ["_static", "_files"]
 templates_path = ["_layout", "_templates"]


### PR DESCRIPTION
The version number is redundant in our release process. Also, it was outdated since it still said `version = "0.1"`