### PR TITLE
Added a step to the git action to pull the latest submodule commits

### DIFF
--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -24,6 +24,9 @@ jobs:
         with:
           submodules: true
 
+      - name: Pull latest from submodules
+        run: git submodule update --recursive --remote
+
       - name: Install Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
This is needed because the site still isn't displaying the latest notebooks 'stable' branch commits automatically.