### PR TITLE
Standardising 'update frequency' field

### DIFF
--- a/docs/data/archive/draft-dea-land-cover-landsat/_data.yaml
+++ b/docs/data/archive/draft-dea-land-cover-landsat/_data.yaml
@@ -11,7 +11,7 @@ spatial_data_type: Raster
 time_span:
   start: null
   end: null
-update_frequency: Annually
+update_frequency: Yearly
 product_ids: null
 
 parent_products:

--- a/docs/data/product/dea-coastlines/_data.yaml
+++ b/docs/data/product/dea-coastlines/_data.yaml
@@ -12,7 +12,7 @@ spatial_data_type: Vector
 time_span:
   start: 1988
   end: 2022
-update_frequency: Annually
+update_frequency: Yearly
 next_update: null
 product_ids: null
 

--- a/docs/data/product/dea-fractional-cover-percentiles-landsat/_data.yaml
+++ b/docs/data/product/dea-fractional-cover-percentiles-landsat/_data.yaml
@@ -12,7 +12,7 @@ spatial_data_type: Raster
 time_span:
   start: 1987
   end: present
-update_frequency: Annually
+update_frequency: Yearly
 next_update: null
 product_ids:
   - ga_ls_fc_pc_cyear_3

--- a/docs/data/product/dea-geometric-median-and-median-absolute-deviation-landsat/_data.yaml
+++ b/docs/data/product/dea-geometric-median-and-median-absolute-deviation-landsat/_data.yaml
@@ -12,7 +12,7 @@ spatial_data_type: Raster
 time_span:
   start: 1986
   end: 2022
-update_frequency: Annually
+update_frequency: Yearly
 next_update: null
 product_ids:
   - ga_ls5t_nbart_gm_cyear_3

--- a/docs/data/product/dea-hotspots/_data.yaml
+++ b/docs/data/product/dea-hotspots/_data.yaml
@@ -12,7 +12,7 @@ spatial_data_type: Vector
 time_span:
   start: 27/08/2002
   end: present
-update_frequency: 10 minutes
+update_frequency: Every 10 minutes
 next_update: null
 product_ids: null
 

--- a/docs/data/product/dea-land-cover-landsat/_data.yaml
+++ b/docs/data/product/dea-land-cover-landsat/_data.yaml
@@ -12,7 +12,7 @@ spatial_data_type: Raster
 time_span:
   start: 1988
   end: 2020
-update_frequency: Annually
+update_frequency: Yearly
 next_update: No updates planned - new version in development
 product_ids:
   - ga_ls_landcover_class_cyear_2

--- a/docs/data/product/dea-mangrove-canopy-cover-landsat/_data.yaml
+++ b/docs/data/product/dea-mangrove-canopy-cover-landsat/_data.yaml
@@ -12,7 +12,7 @@ spatial_data_type: Raster
 time_span:
   start: 1987
   end: 2022
-update_frequency: Annually
+update_frequency: Yearly
 next_update: null
 product_ids:
   - ga_ls_mangrove_cover_cyear_3

--- a/docs/data/product/dea-tasseled-cap-percentiles-landsat/_data.yaml
+++ b/docs/data/product/dea-tasseled-cap-percentiles-landsat/_data.yaml
@@ -12,7 +12,7 @@ spatial_data_type: Raster
 time_span:
   start: 1987
   end: 2022
-update_frequency: Annually
+update_frequency: Yearly
 next_update: null
 product_ids:
   - ga_ls_tc_pc_cyear_3

--- a/docs/data/product/ga-land-cover-terra-modis/_data.yaml
+++ b/docs/data/product/ga-land-cover-terra-modis/_data.yaml
@@ -12,7 +12,7 @@ spatial_data_type: Raster
 time_span:
   start: 2002
   end: 2015
-update_frequency: Biennially
+update_frequency: Every 2 years
 next_update: No updates planned
 product_ids:
   - ga_ter_m_dlcd_ann


### PR DESCRIPTION
Across the data product pages, I standardised the 'Update frequency' field. This is to improve consistency and also to use simpler wording that is easy to understand e.g. changing 'Biennially' to 'Every 2 years'.

I documented these standard values so that others can use them to ensure consistency: <https://docs.dev.dea.ga.gov.au/public_services/dea_knowledge_hub/product_metadata_fields.html#update-frequency>