### PR TITLE
Standardising 'Next update' field

### DIFF
--- a/docs/data/product/dea-burnt-area-characteristic-layers-sentinel-2-near-real-time/_data.yaml
+++ b/docs/data/product/dea-burnt-area-characteristic-layers-sentinel-2-near-real-time/_data.yaml
@@ -13,7 +13,7 @@ time_span:
   start: 1 Jul 2021
   end: 29 Aug 2023
 update_frequency: Daily
-next_update: No further updates planned
+next_update: No updates planned
 product_ids:
   - ga_s2_ba_provisional_3
 

--- a/docs/data/product/dea-intertidal-elevation-landsat/_data.yaml
+++ b/docs/data/product/dea-intertidal-elevation-landsat/_data.yaml
@@ -13,7 +13,7 @@ time_span:
   start: 1986
   end: 2016
 update_frequency: As needed
-next_update: No updates planned - new version in development
+next_update: No updates planned
 product_ids:
   - nidem
 

--- a/docs/data/product/dea-intertidal-elevation-landsat/_details.md
+++ b/docs/data/product/dea-intertidal-elevation-landsat/_details.md
@@ -1,5 +1,11 @@
 ## Background
 
+:::{admonition} New version in development
+:class: note
+
+There are no updates planned for this product because a new version is in development.
+:::
+
 Intertidal environments support important ecological habitats (e.g. sandy beaches and shores, tidal flats and rocky shores and reefs), and provide many valuable benefits such as storm surge protection, carbon storage and natural resources for recreational and commercial use.
 
 Intertidal zones are faced with increasing threats from coastal erosion, land reclamation (e.g. port construction), and sea level rise. Accurate elevation data describing the height and shape of the coastline is needed to help predict when and where these threats will have the greatest impact. However, this data is expensive and challenging to map across the entire intertidal zone of a continent the size of Australia.

--- a/docs/data/product/dea-intertidal-elevation-landsat/_details.md
+++ b/docs/data/product/dea-intertidal-elevation-landsat/_details.md
@@ -3,7 +3,7 @@
 :::{admonition} New version in development
 :class: note
 
-There are no updates planned for this product because a new version is in development.
+No updates are planned for this product because a new version is in development.
 :::
 
 Intertidal environments support important ecological habitats (e.g. sandy beaches and shores, tidal flats and rocky shores and reefs), and provide many valuable benefits such as storm surge protection, carbon storage and natural resources for recreational and commercial use.

--- a/docs/data/product/dea-intertidal-extents-landsat/_data.yaml
+++ b/docs/data/product/dea-intertidal-extents-landsat/_data.yaml
@@ -13,7 +13,7 @@ time_span:
   start: 1986
   end: 2016
 update_frequency: As needed
-next_update: No updates planned - new version in development
+next_update: No updates planned
 product_ids:
   - item_v2
 

--- a/docs/data/product/dea-intertidal-extents-landsat/_details.md
+++ b/docs/data/product/dea-intertidal-extents-landsat/_details.md
@@ -3,7 +3,7 @@
 :::{admonition} New version in development
 :class: note
 
-There are no updates planned for this product because a new version is in development.
+No updates are planned for this product because a new version is in development.
 :::
 
 Intertidal zones are those which are exposed to the air at low tide and underwater at high tide. These include sandy beaches, tidal flats, rocky shores and reefs. 

--- a/docs/data/product/dea-intertidal-extents-landsat/_details.md
+++ b/docs/data/product/dea-intertidal-extents-landsat/_details.md
@@ -1,5 +1,11 @@
 ## Background
 
+:::{admonition} New version in development
+:class: note
+
+There are no updates planned for this product because a new version is in development.
+:::
+
 Intertidal zones are those which are exposed to the air at low tide and underwater at high tide. These include sandy beaches, tidal flats, rocky shores and reefs. 
 
 Intertidal zones form critical habitats for a wide range of organisms, but are faced with increasing threats, including coastal erosion and a rise in sea levels.  

--- a/docs/data/product/dea-land-cover-landsat/_data.yaml
+++ b/docs/data/product/dea-land-cover-landsat/_data.yaml
@@ -13,7 +13,7 @@ time_span:
   start: 1988
   end: 2020
 update_frequency: Annually
-next_update: No updates planned - new version in development
+next_update: No updates planned
 product_ids:
   - ga_ls_landcover_class_cyear_2
 

--- a/docs/data/product/dea-land-cover-landsat/_details.md
+++ b/docs/data/product/dea-land-cover-landsat/_details.md
@@ -1,5 +1,11 @@
 ## Background
 
+:::{admonition} New version in development
+:class: note
+
+There are no updates planned for this product because a new version is in development.
+:::
+
 Land cover is the observed physical cover on the Earth's surface including trees, shrubs, grasses, soils, exposed rocks, water bodies, plantations, crops and built structures. A consistent, Australia-wide land cover product helps understanding of how the different parts of the environment change and inter-relate. Earth observation data recorded over a period of time firstly allows the observation of the state of land cover at a specific time and secondly the way that land cover changes by comparison between times.
 
 ## What this product offers

--- a/docs/data/product/dea-land-cover-landsat/_details.md
+++ b/docs/data/product/dea-land-cover-landsat/_details.md
@@ -3,7 +3,7 @@
 :::{admonition} New version in development
 :class: note
 
-There are no updates planned for this product because a new version is in development.
+No updates are planned for this product because a new version is in development.
 :::
 
 Land cover is the observed physical cover on the Earth's surface including trees, shrubs, grasses, soils, exposed rocks, water bodies, plantations, crops and built structures. A consistent, Australia-wide land cover product helps understanding of how the different parts of the environment change and inter-relate. Earth observation data recorded over a period of time firstly allows the observation of the state of land cover at a specific time and secondly the way that land cover changes by comparison between times.


### PR DESCRIPTION
Across the data product pages, I standardised the 'Next update' field. Now, the text `No updates planned` is used for all fields that contain text.

The text `new version in development` was previously used in this field, however, I've moved that information to a callout box in the Details tab. The reason is that we should try to keep this data in the header as short and standardised as possible, while providing explanatory notes in the content itself. This keeps the header nice and tidy. Let me know if you think this is a good idea.

* [x] I spell-checked my work