### PR TITLE
Added history tab parameter to link in template

### DIFF
--- a/docs/_templates/product-v1.rst
+++ b/docs/_templates/product-v1.rst
@@ -337,7 +337,7 @@
           :name: other-versions
           :class: h2
 
-       You can find the history in the `latest version of the product <{{ data.latest_version_link }}>`_.
+       You can find the history in the `latest version of the product <{{ data.latest_version_link }}?tab=history>`_.
        {% else %}
        .. rubric:: Old versions
           :name: old-versions


### PR DESCRIPTION
Minor change. Made link from old product's history tab to new product be linked directly to the history tab.